### PR TITLE
Fix DomainException path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
-import { DomainExceptionFilter } from '@module/users/application/filters/domain.exception.filter';
+import { DomainExceptionFilter } from './core/common/filters/domain.exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
# Fix main paths
- fix `DomainExceptionFilter` from `'@module/users/application/filters/domain.exception.filter';` to `./core/common/filters/domain.exception.filter` when this used by more than one entity so it's become shared from one source to apply reusability is possible and make code D.R.Y.