### PR TITLE
Auth system

### DIFF
--- a/src/module/auth/application/auth.facade.ts
+++ b/src/module/auth/application/auth.facade.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { SignInUseCase } from './usecases/sign-in/sign-in.usecase';
 import { EmailVerificationUseCase } from './usecases/email-verification/email-verification.usecase';
 import { RegisterationUseCase } from './usecases/registeration/registeration.usecase';
+import { ResendVerificationCodeUseCase } from './usecases/resend-verification-code/resend-verification-code.usecase';
+import { ForgotPasswordUseCase } from './usecases/forgot-password/forgot-password.usecase';
+import { VerifyResetPasswordCodeUseCase } from './usecases/verify-reset-password-code/verify-reset-password-code.usecase';
+import { ResetPasswordUseCase } from './usecases/reset-password/reset-password.usecase';
+import { RefreshTokenUseCase } from './usecases/refresh-token/refresh-token.usecase';
 
 @Injectable()
 export class AuthFacade {
@@ -9,5 +14,10 @@ export class AuthFacade {
     public readonly SignIn: SignInUseCase,
     public readonly emailVerification: EmailVerificationUseCase,
     public readonly signup: RegisterationUseCase,
+    public readonly resendCode: ResendVerificationCodeUseCase,
+    public readonly forgorPassword: ForgotPasswordUseCase,
+    public readonly verifyResetCode: VerifyResetPasswordCodeUseCase,
+    public readonly resetPassword: ResetPasswordUseCase,
+    public readonly refreshToken: RefreshTokenUseCase,
   ) {}
 }

--- a/src/module/auth/application/usecases/email-verification/email-verification.response.ts
+++ b/src/module/auth/application/usecases/email-verification/email-verification.response.ts
@@ -4,5 +4,6 @@ export class EmailVerificationResponse {
   constructor(
     public user: User,
     public accessToken: string,
+    public refreshToken: string,
   ) {}
 }

--- a/src/module/auth/application/usecases/email-verification/email-verification.spec.ts
+++ b/src/module/auth/application/usecases/email-verification/email-verification.spec.ts
@@ -15,9 +15,9 @@ describe('Code verification test cases', () => {
     generate: jest.fn(),
   };
 
-  const mockRedis = {
-    get: jest.fn(),
-    del: jest.fn(),
+  const mockOTPRepo = {
+    getResetCode: jest.fn(),
+    delResetCode: jest.fn(),
   };
 
   const mockConfig = {
@@ -28,7 +28,7 @@ describe('Code verification test cases', () => {
     useCase = new EmailVerificationUseCase(
       mockUserRepo as any,
       mockJwtService as any,
-      mockRedis as any,
+      mockOTPRepo as any,
       mockConfig as any,
     );
 
@@ -66,25 +66,34 @@ describe('Code verification test cases', () => {
       value: user,
     });
 
-    mockRedis.get.mockResolvedValue(hashedCode);
+    mockOTPRepo.getResetCode.mockResolvedValue({
+      ok: true,
+      value: hashedCode,
+    });
     mockJwtService.generate.mockResolvedValue('fake-token-gen');
 
     const result = await useCase.execute({ email, code: rawCode });
 
     expect(result.ok).toBe(true);
+
     if (result.ok) {
       expect(result.value.accessToken).toBe('fake-token-gen');
       expect(result.value.user.getIsVerified()).toBe(true);
     }
     expect(mockUserRepo.save).toHaveBeenCalled();
-    expect(mockRedis.del).toHaveBeenCalledWith(`verify:${user.getId()}`);
+    expect(mockOTPRepo.delResetCode).toHaveBeenCalledWith(
+      `verify:${user.getId()}`,
+    );
   });
 
   it('should fail when verification code expired in redis', async () => {
     const user = createUser();
 
     mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
-    mockRedis.get.mockResolvedValue(null);
+    mockOTPRepo.getResetCode.mockResolvedValue({
+      ok: true,
+      value: null,
+    });
 
     const result = await useCase.execute({ email, code: rawCode });
 
@@ -111,7 +120,7 @@ describe('Code verification test cases', () => {
     if (!result.ok) {
       expect(result.error.message).toBe('Email already verified');
     }
-    expect(mockRedis.get).not.toHaveBeenCalled();
+    expect(mockOTPRepo.delResetCode).not.toHaveBeenCalled();
     expect(mockUserRepo.save).not.toHaveBeenCalled();
   });
 });

--- a/src/module/auth/application/usecases/email-verification/email-verification.usecase.ts
+++ b/src/module/auth/application/usecases/email-verification/email-verification.usecase.ts
@@ -3,15 +3,17 @@ import { Result } from '@/core/common/result.pattern';
 import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
-import { IJWTTOKEN_SERVICE } from '@/module/auth/domain/constants/injection.token';
+import {
+  IJWTTOKEN_SERVICE,
+  IOTP_REPOSITORY,
+} from '@/module/auth/domain/constants/injection.token';
 import type { IJWTTokenService } from '@/module/auth/domain/service/token.service.interface';
-import { InjectRedis } from '@nestjs-modules/ioredis';
-import Redis from 'ioredis';
 import { EmailVerificationRequest } from './email-verification.request';
 import { EmailVerificationResponse } from './email-verification.response';
 import { Errors, failure } from '@/core/common/err.utils';
 import { createHash } from 'crypto';
 import { ConfigService } from '@nestjs/config';
+import type { IOTPRepository } from '@/module/auth/domain/repository/otp.repsoitory.interface';
 
 @Injectable()
 export class EmailVerificationUseCase implements IUseCase<
@@ -21,7 +23,7 @@ export class EmailVerificationUseCase implements IUseCase<
   constructor(
     @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
     @Inject(IJWTTOKEN_SERVICE) private readonly tokenService: IJWTTokenService,
-    @InjectRedis() private readonly redis: Redis,
+    @Inject(IOTP_REPOSITORY) private readonly otpRepo: IOTPRepository,
     private readonly config: ConfigService,
   ) {}
 
@@ -39,14 +41,19 @@ export class EmailVerificationUseCase implements IUseCase<
 
     const inputHash = createHash('sha256').update(dto.code).digest('hex');
 
-    const savedCode = await this.redis.get(`verify:${user.getId()}`);
+    const savedCodeResult = await this.otpRepo.getResetCode(
+      `verify:${user.getId()}`,
+    );
 
-    if (!savedCode)
+    if (!savedCodeResult.ok)
+      return failure(Errors.internal('Failed to retrive code'));
+
+    if (!savedCodeResult.value)
       return failure(
-        Errors.validation('Verification code has expired or was never sent'),
+        Errors.internal('Verification code has expired or was never sent'),
       );
 
-    if (inputHash !== savedCode)
+    if (inputHash !== savedCodeResult.value)
       return failure(Errors.validation('Incorrect verification code'));
 
     const id = user.getId(),
@@ -73,13 +80,13 @@ export class EmailVerificationUseCase implements IUseCase<
 
     // atomic clean up and save
     await Promise.all([
-      this.redis.del(`verify:${user.getId()}`),
+      this.otpRepo.delResetCode(`verify:${user.getId()}`),
       this.userRepo.save(finalUser),
     ]);
 
     return {
       ok: true,
-      value: { user: finalUser, accessToken },
+      value: { user: finalUser, accessToken, refreshToken },
     };
   }
 }

--- a/src/module/auth/application/usecases/event-handler/auth-email-handler.ts
+++ b/src/module/auth/application/usecases/event-handler/auth-email-handler.ts
@@ -1,0 +1,53 @@
+import { IEMAIL_SERVICE } from '@/module/auth/domain/constants/injection.token';
+import { RegisterationCodeRequedEvent } from '@/module/auth/domain/events/registeration-code.requested';
+import { ResendVerificationCodeRequestedEvent } from '@/module/auth/domain/events/resend-verification-code-requested.event';
+import { ResetPasswordRequestedEvent } from '@/module/auth/domain/events/reset-password-requested.event';
+import { IEmailService } from '@/module/auth/domain/service/email.service.interface';
+import { Inject } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+
+type EventType =
+  | RegisterationCodeRequedEvent
+  | ResendVerificationCodeRequestedEvent
+  | ResetPasswordRequestedEvent;
+
+@EventsHandler(
+  ResendVerificationCodeRequestedEvent,
+  ResetPasswordRequestedEvent,
+  RegisterationCodeRequedEvent,
+)
+export class AuthSendEmail implements IEventHandler<
+  ResendVerificationCodeRequestedEvent | ResetPasswordRequestedEvent
+> {
+  constructor(
+    @Inject(IEMAIL_SERVICE) private readonly emailService: IEmailService,
+  ) {}
+
+  async handle(event: EventType) {
+    const subject = this._getSubject(event);
+    try {
+      await this.emailService.send(
+        event.email,
+        subject,
+        `Your new code is <br /> ${event.code} <br /> it valid only for 10 min`,
+      );
+    } catch {
+      // return failure(Errors.internal(`Failed send code to ${event.email}`));
+      // This event is fire and forgot so we need to log error
+      // ***TO DO***
+    }
+  }
+
+  private _getSubject(event: EventType): string {
+    switch (event.action) {
+      case 'RESET':
+        return 'Reset Password Code';
+      case 'RESEND':
+        return 'Resend Password Code';
+      case 'REGISTERATION':
+        return 'Registeration Code';
+      default:
+        return 'Authentication Notification';
+    }
+  }
+}

--- a/src/module/auth/application/usecases/forgot-password/forgot-password.request.ts
+++ b/src/module/auth/application/usecases/forgot-password/forgot-password.request.ts
@@ -1,3 +1,3 @@
-export class ForgorPasswordRequest {
+export class ForgotPasswordRequest {
   constructor(public readonly email: string) {}
 }

--- a/src/module/auth/application/usecases/forgot-password/forgot-password.response.ts
+++ b/src/module/auth/application/usecases/forgot-password/forgot-password.response.ts
@@ -1,3 +1,0 @@
-export class ForgotPasswordResponse {
-  constructor(public message: string) {}
-}

--- a/src/module/auth/application/usecases/forgot-password/forgot-password.spec.ts
+++ b/src/module/auth/application/usecases/forgot-password/forgot-password.spec.ts
@@ -20,7 +20,7 @@ describe('Forgot password test cases', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       isPasswordCodeVerified: false,
-      passwordUpdatedAt: new Date(),
+      passwordUpdatedAt: null,
       ...override,
     });
   };
@@ -29,19 +29,19 @@ describe('Forgot password test cases', () => {
     findByEmail: jest.fn(),
   };
 
-  const mockRedis = {
-    set: jest.fn(),
+  const mockOTPRepo = {
+    setResetCode: jest.fn(),
   };
 
-  const mockEmail = {
-    send: jest.fn(),
+  const mockEventPublisher = {
+    publish: jest.fn(),
   };
 
   beforeEach(() => {
     useCase = new ForgotPasswordUseCase(
       mockUserRepo as any,
-      mockRedis as any,
-      mockEmail as any,
+      mockOTPRepo as any,
+      mockEventPublisher as any,
     );
 
     jest.clearAllMocks();
@@ -63,16 +63,15 @@ describe('Forgot password test cases', () => {
     const hashedCode = createHash('sha256').update(expectedCode).digest('hex');
 
     if (result.ok) {
-      expect(result.value.message).toBe('Code successfully sent to your email');
+      expect(result.value).toBe('Code successfully sent to your email');
     }
 
-    expect(mockRedis.set).toHaveBeenCalledWith(
+    expect(mockOTPRepo.setResetCode).toHaveBeenCalledWith(
       `reset_password:${user.getId()}`,
       hashedCode,
-      'EX',
       600,
     );
-    expect(mockEmail.send).toHaveBeenCalled();
+    expect(mockEventPublisher.publish).toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/src/module/auth/application/usecases/forgot-password/forgot-password.usecase.ts
+++ b/src/module/auth/application/usecases/forgot-password/forgot-password.usecase.ts
@@ -1,61 +1,65 @@
 import { IUseCase } from '@/core/common/use-case-interface';
-import { ForgorPasswordRequest } from './forgot-password.request';
-import { ForgotPasswordResponse } from './forgot-password.response';
+import { ForgotPasswordRequest } from './forgot-password.request';
 import { Result } from '@core/common/result.pattern';
 import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
 import { Inject } from '@nestjs/common';
 import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
-import { InjectRedis } from '@nestjs-modules/ioredis';
-import Redis from 'ioredis';
 import { createHash } from 'crypto';
-import { IEMAIL_SERVICE } from '@/module/auth/domain/constants/injection.token';
-import type { IEmailService } from '@/module/auth/domain/service/email.service.interface';
+import { IOTP_REPOSITORY } from '@/module/auth/domain/constants/injection.token';
 import { Errors, failure } from '@/core/common/err.utils';
-
-type PassResutl = Promise<Result<ForgotPasswordResponse>>;
+import type { IOTPRepository } from '@/module/auth/domain/repository/otp.repsoitory.interface';
+import { EventBus } from '@nestjs/cqrs';
+import { ResetPasswordRequestedEvent } from '@/module/auth/domain/events/reset-password-requested.event';
 
 export class ForgotPasswordUseCase implements IUseCase<
-  ForgorPasswordRequest,
-  PassResutl
+  ForgotPasswordRequest,
+  Promise<Result<string>>
 > {
   constructor(
     @Inject(IUSER_REPOSITORY) private readonly userRep: IUserRepository,
-    @InjectRedis() private readonly redis: Redis,
-    @Inject(IEMAIL_SERVICE) private emailService: IEmailService,
+    @Inject(IOTP_REPOSITORY) private readonly otpRep: IOTPRepository,
+    private readonly eventPublisher: EventBus,
   ) {}
-  async execute(dto: ForgorPasswordRequest): PassResutl {
+  async execute(dto: ForgotPasswordRequest): Promise<Result<string>> {
     const userResult = await this.userRep.findByEmail(dto.email);
 
     if (!userResult.ok) return userResult;
 
     const user = userResult.value;
 
+    const passwordUpdated = user.getPasswordUpdatedAt();
+
+    if (passwordUpdated) {
+      const now = new Date();
+      const diffMs = now.getTime() - passwordUpdated.getTime();
+
+      const THIRTY_MINS = 30 * 60 * 1000;
+      // block user to update for 30mins
+      if (diffMs <= THIRTY_MINS)
+        return failure(
+          Errors.validation('Password was reset recently try later'),
+        );
+    }
     // Generate code
     const generateCode = Math.floor(100000 + Math.random() * 900000).toString();
     // Hashed code
     const hashedCode = createHash('sha256').update(generateCode).digest('hex');
 
     // save code in redis
-    await this.redis.set(
+    await this.otpRep.setResetCode(
       `reset_password:${user.getId()}`,
       hashedCode,
-      'EX',
       600,
     );
 
-    try {
-      await this.emailService.send(
-        user.getEmail(),
-        'Reset password Code',
-        `Your have request code to reset password<br /> code: ${generateCode} <br />it's only valid for 10 min`,
-      );
+    // trigger email event
+    this.eventPublisher.publish(
+      new ResetPasswordRequestedEvent(user.getEmail(), generateCode),
+    );
 
-      return {
-        ok: true,
-        value: { message: 'Code successfully sent to your email' },
-      };
-    } catch {
-      return failure(Errors.validation('Code failed to sent'));
-    }
+    return {
+      ok: true,
+      value: 'Code successfully sent to your email',
+    };
   }
 }

--- a/src/module/auth/application/usecases/refresh-token/refresh-token.spec.ts
+++ b/src/module/auth/application/usecases/refresh-token/refresh-token.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RefreshTokenUseCase } from './refresh-token.usecase';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import {
+  IBCRYPT_SERVICE,
+  IJWTTOKEN_SERVICE,
+} from '@/module/auth/domain/constants/injection.token';
+import { User } from '@/module/users/domain/entity/user.entity';
+import { UserRole } from '@/module/users/domain/interface/role.interface';
+import { ConfigService } from '@nestjs/config';
+
+describe('Refresh token usecase', () => {
+  const createUser = (override?: Partial<any>) => {
+    return User.rehydrate({
+      email: 'test@example.com',
+      username: 'test',
+      id: 'user-123',
+      isPasswordCodeVerified: false,
+      password: 'hashed-pass',
+      emailVerified: null,
+      isVerified: true,
+      passwordUpdatedAt: null,
+      phone: null,
+      refreshToken: 'some-token',
+      role: 'Studen' as UserRole,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+      ...override,
+    });
+  };
+
+  let usecase: RefreshTokenUseCase;
+
+  let mockBcryptService: {
+    compare: jest.Mock;
+    hash: jest.Mock;
+  };
+
+  let mockUserRepo: {
+    findByEmail: jest.Mock;
+    save: jest.Mock;
+  };
+
+  let mockTokenService: {
+    generate: jest.Mock;
+    verify: jest.Mock;
+    generateAuthToken: jest.Mock;
+  };
+
+  let mockConfig: { getOrThrow: jest.Mock };
+
+  beforeEach(async () => {
+    mockUserRepo = {
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+    };
+
+    mockTokenService = {
+      generate: jest.fn(),
+      verify: jest.fn(),
+      generateAuthToken: jest.fn(),
+    };
+
+    mockBcryptService = {
+      compare: jest.fn(),
+      hash: jest.fn(),
+    };
+
+    mockConfig = {
+      getOrThrow: jest.fn().mockReturnValue('mock-secret'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RefreshTokenUseCase,
+        {
+          provide: IUSER_REPOSITORY,
+          useValue: mockUserRepo,
+        },
+        {
+          provide: IBCRYPT_SERVICE,
+          useValue: mockBcryptService,
+        },
+        {
+          provide: IJWTTOKEN_SERVICE,
+          useValue: mockTokenService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfig,
+        },
+      ],
+    }).compile();
+
+    usecase = module.get<RefreshTokenUseCase>(RefreshTokenUseCase);
+  });
+
+  it('should success when user token is valid', async () => {
+    const user = createUser();
+
+    mockTokenService.verify.mockResolvedValue({
+      id: user.getId(),
+      email: user.getEmail(),
+      role: user.getRole(),
+    });
+
+    mockUserRepo.findByEmail.mockResolvedValue({
+      ok: true,
+      value: user,
+    });
+
+    mockBcryptService.compare.mockResolvedValue(true);
+
+    mockTokenService.generateAuthToken.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+
+    mockUserRepo.save.mockResolvedValue({ ok: true });
+
+    mockBcryptService.hash.mockResolvedValue('new-hash-token');
+
+    const result = await usecase.execute('any-old-token');
+
+    expect(result.ok).toBe(true);
+
+    if (result.ok) {
+      expect(result.value).toEqual({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+      });
+    }
+  });
+
+  it('should fail when hashed token and old token do not matched', async () => {
+    const user = createUser();
+
+    mockTokenService.verify.mockResolvedValue({
+      id: user.getId(),
+      email: user.getEmail(),
+      role: user.getRole(),
+    });
+
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+    mockBcryptService.compare.mockResolvedValue(false);
+
+    const result = await usecase.execute('old-token');
+
+    expect(result.ok).toBe(false);
+
+    expect(mockBcryptService.hash).not.toHaveBeenCalled();
+    expect(mockTokenService.generateAuthToken).not.toHaveBeenCalled();
+
+    // should be called to remove token
+    expect(mockUserRepo.save).toHaveBeenCalled();
+  });
+});

--- a/src/module/auth/application/usecases/refresh-token/refresh-token.usecase.ts
+++ b/src/module/auth/application/usecases/refresh-token/refresh-token.usecase.ts
@@ -1,0 +1,89 @@
+import { Errors, failure } from '@/core/common/err.utils';
+import { IUseCase } from '@/core/common/use-case-interface';
+import {
+  IBCRYPT_SERVICE,
+  IJWTTOKEN_SERVICE,
+} from '@/module/auth/domain/constants/injection.token';
+import type { IBcryptService } from '@/module/auth/domain/service/bcrypt.service.interface';
+import type { IJWTTokenService } from '@/module/auth/domain/service/token.service.interface';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
+import { Result } from '@core/common/result.pattern';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class RefreshTokenUseCase implements IUseCase<
+  string,
+  Promise<Result<{ refreshToken: string; accessToken: string }>>
+> {
+  constructor(
+    @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
+    @Inject(IBCRYPT_SERVICE) private readonly bcryptService: IBcryptService,
+    @Inject(IJWTTOKEN_SERVICE) private readonly tokenServie: IJWTTokenService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async execute(
+    oldRefreshToken: string,
+  ): Promise<Result<{ refreshToken: string; accessToken: string }>> {
+    const secret = this.config.getOrThrow<string>('JWT_REFRESH_TOKEN_SECRET');
+
+    const verifyingToken = await this.tokenServie.verify(
+      oldRefreshToken,
+      secret,
+    );
+
+    if (!verifyingToken)
+      return failure(Errors.unauthroized('Invalid or expired refreshToken'));
+
+    const payload = {
+      id: verifyingToken.id,
+      email: verifyingToken.email,
+      role: verifyingToken.role,
+    };
+
+    if (!payload) return failure(Errors.validation('Invalid token signature'));
+
+    const userResult = await this.userRepo.findByEmail(payload.email);
+
+    if (!userResult.ok)
+      return failure(Errors.notFound('User not found it may be deleted'));
+
+    const user = userResult.value;
+
+    const hashedTokenInDb = user.getRefreshToken();
+
+    const isTokensMatched = hashedTokenInDb
+      ? await this.bcryptService.compare(oldRefreshToken, hashedTokenInDb)
+      : false;
+
+    if (!isTokensMatched) {
+      const removeRefreshToken = user.updateRefreshToken(null);
+      await this.userRepo.save(removeRefreshToken);
+      return failure(Errors.unauthroized('Session expired or compromised'));
+    }
+
+    if (!user) return failure(Errors.unauthroized('User not authorized'));
+
+    // generate new rotation
+    const tokens = await this.tokenServie.generateAuthToken(payload);
+
+    // we need to hash refresh token before save it to database
+    const newHashRefreshToken = await this.bcryptService.hash(
+      tokens.refreshToken,
+    );
+
+    const updateUserRefreshToken = user.updateRefreshToken(newHashRefreshToken);
+
+    await this.userRepo.save(updateUserRefreshToken);
+
+    return {
+      ok: true,
+      value: {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+      },
+    };
+  }
+}

--- a/src/module/auth/application/usecases/registeration/registeration.spec.ts
+++ b/src/module/auth/application/usecases/registeration/registeration.spec.ts
@@ -13,20 +13,20 @@ describe('Registeration test cases', () => {
     hash: jest.fn(),
   };
 
-  const mockRedis = {
-    set: jest.fn(),
+  const mockOTPRepo = {
+    setResetCode: jest.fn(),
   };
 
-  const mockEmail = {
-    send: jest.fn(),
+  const mockEventPublisher = {
+    publish: jest.fn(),
   };
 
   beforeEach(() => {
     useCase = new RegisterationUseCase(
       mockUserRepo as any,
       mockBcryptService as any,
-      mockRedis as any,
-      mockEmail as any,
+      mockOTPRepo as any,
+      mockEventPublisher as any,
     );
 
     jest.clearAllMocks();
@@ -55,11 +55,10 @@ describe('Registeration test cases', () => {
     if (result.ok) {
       expect(mockBcryptService.hash).toHaveBeenCalledWith('hashed-pass');
       expect(mockUserRepo.save).toHaveBeenCalled();
-      expect(mockEmail.send).toHaveBeenCalled();
-      expect(mockRedis.set).toHaveBeenCalledWith(
+      expect(mockEventPublisher.publish).toHaveBeenCalled();
+      expect(mockOTPRepo.setResetCode).toHaveBeenCalledWith(
         `verify:user-123`,
         hashedCode,
-        'EX',
         600,
       );
     }

--- a/src/module/auth/application/usecases/registeration/registeration.usecase.ts
+++ b/src/module/auth/application/usecases/registeration/registeration.usecase.ts
@@ -1,4 +1,4 @@
-import { IUseCase } from '@/core/common/use-case-interface';
+import type { IUseCase } from '@/core/common/use-case-interface';
 import { RegisterationRequest } from './registeration.request';
 import { Result } from '@core/common/result.pattern';
 import { Inject, Injectable } from '@nestjs/common';
@@ -7,15 +7,15 @@ import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.toke
 import type { IBcryptService } from '@/module/auth/domain/service/bcrypt.service.interface';
 import {
   IBCRYPT_SERVICE,
-  IEMAIL_SERVICE,
+  IOTP_REPOSITORY,
 } from '@/module/auth/domain/constants/injection.token';
 import { Errors, failure } from '@/core/common/err.utils';
 import { User } from '@/module/users/domain/entity/user.entity';
 import { UserRole } from '@/module/users/domain/interface/role.interface';
 import { createHash } from 'crypto';
-import { InjectRedis } from '@nestjs-modules/ioredis';
-import Redis from 'ioredis';
-import { IEmailService } from '@/module/auth/domain/service/email.service.interface';
+import type { IOTPRepository } from '@/module/auth/domain/repository/otp.repsoitory.interface';
+import { EventBus } from '@nestjs/cqrs';
+import { RegisterationCodeRequedEvent } from '@/module/auth/domain/events/registeration-code.requested';
 
 @Injectable()
 export class RegisterationUseCase implements IUseCase<
@@ -24,9 +24,9 @@ export class RegisterationUseCase implements IUseCase<
 > {
   constructor(
     @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
-    @Inject(IBCRYPT_SERVICE) private readonly hash: IBcryptService,
-    @InjectRedis() private readonly redis: Redis,
-    @Inject(IEMAIL_SERVICE) private readonly email: IEmailService,
+    @Inject(IBCRYPT_SERVICE) private readonly hashService: IBcryptService,
+    @Inject(IOTP_REPOSITORY) private readonly otpRepo: IOTPRepository,
+    private readonly eventPublisher: EventBus,
   ) {}
 
   async execute(dto: RegisterationRequest): Promise<Result<string>> {
@@ -35,7 +35,7 @@ export class RegisterationUseCase implements IUseCase<
     if (emailResult.ok) return failure(Errors.conflict('Email already exists'));
 
     // hashing user password
-    const hashedPassword = await this.hash.hash(dto.password);
+    const hashedPassword = await this.hashService.hash(dto.password);
 
     const user = User.create({
       email: dto.email,
@@ -59,12 +59,17 @@ export class RegisterationUseCase implements IUseCase<
 
     try {
       // save the digits to redis
-      await this.redis.set(`verify:${user.getId()}`, hashedCode, 'EX', 600);
-      await this.email.send(
-        user.getEmail(),
-        'Your verification code',
-        `Your verification Code is <br /> <b>${verificationCode}</b> <br /> Valid for 10 mins`,
+      await this.otpRepo.setResetCode(
+        `verify:${user.getId()}`,
+        hashedCode,
+        600,
       );
+
+      // Trigger event to send mail
+      this.eventPublisher.publish(
+        new RegisterationCodeRequedEvent(user.getEmail(), verificationCode),
+      );
+
       return {
         ok: true,
         value: 'Please verify your account',

--- a/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.param.ts
+++ b/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.param.ts
@@ -1,0 +1,5 @@
+export class ResendVerificaionCodeParam {
+  constructor(public readonly email: string) {
+    if (!this.email) throw new Error('Email is missing');
+  }
+}

--- a/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.spec.ts
+++ b/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.spec.ts
@@ -1,0 +1,95 @@
+import { User } from '@/module/users/domain/entity/user.entity';
+import { ResendVerificationCodeUseCase } from './resend-verification-code.usecase';
+import { UserRole } from '@/module/users/domain/interface/role.interface';
+import { createHash } from 'crypto';
+import { Errors } from '@/core/common/err.utils';
+
+describe('Resend Code verification test cases', () => {
+  let usecase: ResendVerificationCodeUseCase;
+
+  const mockUserRepo = {
+    findByEmail: jest.fn(),
+  };
+
+  const mockEventPublisher = {
+    publish: jest.fn(),
+  };
+
+  const mockOTPRepo = {
+    setResetCode: jest.fn(),
+  };
+
+  beforeEach(() => {
+    usecase = new ResendVerificationCodeUseCase(
+      mockUserRepo as any,
+      mockOTPRepo as any,
+      mockEventPublisher as any,
+    );
+
+    jest.clearAllMocks();
+  });
+
+  const user = User.rehydrate({
+    email: 'test@example.com',
+    username: 'mr.test',
+    role: 'Student' as UserRole,
+    id: 'id-123',
+    isVerified: false,
+    isPasswordCodeVerified: false,
+    emailVerified: null,
+    password: 'hashed-password',
+    passwordUpdatedAt: null,
+    refreshToken: 'random-refresh-token',
+    phone: '84784738473',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  it('should return message to verify account', async () => {
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+
+    // we need id to be more predictable to make test successed
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('id-123' as any);
+
+    // we need to simulate creating new code
+    // when this suppose to return .3 so our formula will be
+    // (100000 + 0.3 * 900000) = 370000
+    jest.spyOn(Math, 'random').mockReturnValue(0.3);
+
+    const result = await usecase.execute({ email: 'test@example.com' });
+
+    // or formula
+    const fakeCode = Math.floor(100000 + Math.random() * 900000).toString();
+    const hashingCode = createHash('sha256').update(fakeCode).digest('hex');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('Verification code was sent.');
+    }
+
+    expect(mockEventPublisher.publish).toHaveBeenCalled();
+    expect(mockOTPRepo.setResetCode).toHaveBeenCalledWith(
+      `verify:${user.getId()}`,
+      hashingCode,
+      600,
+    );
+  });
+
+  it('should exit earlier when user already verified', async () => {
+    const verifiedUser = user.verify();
+    mockUserRepo.findByEmail.mockResolvedValue({
+      ok: true,
+      value: verifiedUser,
+    });
+
+    const result = await usecase.execute({ email: 'test@example.com' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual(Errors.validation('Email already verified'));
+    }
+    expect(mockUserRepo.findByEmail).toHaveBeenCalledTimes(1);
+    expect(mockOTPRepo.setResetCode).not.toHaveBeenCalled();
+    expect(mockEventPublisher.publish).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.usecase.ts
+++ b/src/module/auth/application/usecases/resend-verification-code/resend-verification-code.usecase.ts
@@ -1,0 +1,62 @@
+import type { IUseCase } from '@/core/common/use-case-interface';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
+import { Result } from '@core/common/result.pattern';
+import { Inject, Injectable } from '@nestjs/common';
+import { IOTP_REPOSITORY } from '../../../domain/constants/injection.token';
+import type { IOTPRepository } from '../../../domain/repository/otp.repsoitory.interface';
+import { Errors, failure } from '@/core/common/err.utils';
+import { createHash } from 'crypto';
+import { ResendVerificaionCodeParam } from './resend-verification-code.param';
+import { EventBus } from '@nestjs/cqrs';
+import { ResendVerificationCodeRequestedEvent } from '@/module/auth/domain/events/resend-verification-code-requested.event';
+
+@Injectable()
+export class ResendVerificationCodeUseCase implements IUseCase<
+  ResendVerificaionCodeParam,
+  Promise<Result<string>>
+> {
+  constructor(
+    @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
+    @Inject(IOTP_REPOSITORY) private readonly otpRepository: IOTPRepository,
+    private readonly eventPublisher: EventBus,
+  ) {}
+
+  async execute(dto: ResendVerificaionCodeParam): Promise<Result<string>> {
+    const userResult = await this.userRepo.findByEmail(dto.email);
+    if (!userResult.ok) return failure(Errors.notFound('Email not found'));
+
+    const user = userResult.value;
+    if (user.getIsVerified())
+      return failure(Errors.validation('Email already verified'));
+
+    const generateNewCode = Math.floor(
+      100000 + Math.random() * 900000,
+    ).toString();
+
+    const hashedNewCode = createHash('sha256')
+      .update(generateNewCode)
+      .digest('hex');
+
+    // save it to redis and send code in user email
+
+    await this.otpRepository.setResetCode(
+      `verify:${user.getId()}`,
+      hashedNewCode,
+      600,
+    );
+
+    // Trigger event
+    this.eventPublisher.publish(
+      new ResendVerificationCodeRequestedEvent(
+        user.getEmail(),
+        generateNewCode,
+      ),
+    );
+
+    return {
+      ok: true,
+      value: 'Verification code was sent.',
+    };
+  }
+}

--- a/src/module/auth/application/usecases/reset-password/reset-password.spec.ts
+++ b/src/module/auth/application/usecases/reset-password/reset-password.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResetPasswordUseCase } from './reset-password.usecase';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import {
+  IBCRYPT_SERVICE,
+  IJWTTOKEN_SERVICE,
+} from '@/module/auth/domain/constants/injection.token';
+import { ConfigService } from '@nestjs/config';
+import { User } from '@/module/users/domain/entity/user.entity';
+import { UserRole } from '@/module/users/domain/interface/role.interface';
+
+describe('Reset password test cases', () => {
+  const createUser = (override?: Partial<any>) => {
+    return User.rehydrate({
+      email: 'test@example.com',
+      username: 'test',
+      id: 'user-123',
+      isPasswordCodeVerified: false,
+      password: 'hashed-pass',
+      emailVerified: null,
+      isVerified: true,
+      passwordUpdatedAt: null,
+      phone: null,
+      refreshToken: 'some-token',
+      role: 'Studen' as UserRole,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+      ...override,
+    });
+  };
+
+  let usecase: ResetPasswordUseCase;
+
+  let mockUserRepo: { findByEmail: jest.Mock; save: jest.Mock };
+  let mockBcryptService: { hash: jest.Mock };
+  let mockTokenService: { generate: jest.Mock; generateAuthToken: jest.Mock };
+  let mockConfigService: { getOrThrow: jest.Mock };
+
+  beforeEach(async () => {
+    mockUserRepo = {
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+    };
+    mockBcryptService = {
+      hash: jest.fn(),
+    };
+    mockTokenService = {
+      generate: jest.fn(),
+      generateAuthToken: jest.fn(),
+    };
+    mockConfigService = {
+      getOrThrow: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResetPasswordUseCase,
+        {
+          provide: IUSER_REPOSITORY,
+          useValue: mockUserRepo,
+        },
+        {
+          provide: IBCRYPT_SERVICE,
+          useValue: mockBcryptService,
+        },
+        {
+          provide: IJWTTOKEN_SERVICE,
+          useValue: mockTokenService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    usecase = module.get<ResetPasswordUseCase>(ResetPasswordUseCase);
+  });
+
+  it('should success if password verified', async () => {
+    const user = createUser({ isPasswordCodeVerified: true });
+
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+
+    mockBcryptService.hash.mockResolvedValue('hashing-string');
+    mockTokenService.generateAuthToken.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+
+    const result = await usecase.execute({
+      email: 'test@example.com',
+      newPassword: 'new-pass',
+      confirmPassword: 'new-pass',
+    });
+
+    expect(mockBcryptService.hash).toHaveBeenCalledTimes(2);
+
+    expect(result.ok).toBeTruthy();
+    expect(mockUserRepo.save).toHaveBeenCalledTimes(1);
+    expect(mockTokenService.generateAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('should failed when user not veriified', async () => {
+    const user = createUser();
+
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+
+    const result = await usecase.execute({
+      email: 'test@example.com',
+      newPassword: 'new-pass',
+      confirmPassword: 'new-pass',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(mockUserRepo.save).not.toHaveBeenCalled();
+    expect(mockTokenService.generateAuthToken).not.toHaveBeenCalled();
+    expect(mockBcryptService.hash).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/auth/application/usecases/reset-password/reset-password.usecase.ts
+++ b/src/module/auth/application/usecases/reset-password/reset-password.usecase.ts
@@ -1,0 +1,79 @@
+import { Errors, failure } from '@/core/common/err.utils';
+import { IUseCase } from '@/core/common/use-case-interface';
+import {
+  IBCRYPT_SERVICE,
+  IJWTTOKEN_SERVICE,
+} from '@/module/auth/domain/constants/injection.token';
+import type { IBcryptService } from '@/module/auth/domain/service/bcrypt.service.interface';
+import type { IJWTTokenService } from '@/module/auth/domain/service/token.service.interface';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import { User } from '@/module/users/domain/entity/user.entity';
+import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
+import { Result } from '@core/common/result.pattern';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class ResetPasswordUseCase implements IUseCase<
+  { email: string; newPassword: string; confirmPassword: string },
+  Promise<Result<{ user: User; accessToken: string; refreshToken: string }>>
+> {
+  constructor(
+    @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
+    @Inject(IJWTTOKEN_SERVICE) private readonly tokenService: IJWTTokenService,
+    @Inject(IBCRYPT_SERVICE) private readonly bcryptService: IBcryptService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async execute(dto: {
+    email: string;
+    newPassword: string;
+    confirmPassword: string;
+  }): Promise<
+    Result<{ user: User; accessToken: string; refreshToken: string }>
+  > {
+    const userResult = await this.userRepo.findByEmail(dto.email);
+
+    if (dto.newPassword.length < 6)
+      return failure(Errors.validation('Password too short'));
+
+    if (!userResult.ok) return failure(Errors.notFound('User not found'));
+    const user = userResult.value;
+    // check if code verified
+    if (!user.getIsPasswordCodeVerified())
+      return failure(Errors.validation('Reset code not verified'));
+
+    // Check if passwords doesn't matched
+    if (dto.confirmPassword !== dto.newPassword)
+      return failure(Errors.validation("Passwords don't match"));
+
+    // we need to hash user password
+    const hashedPassword = await this.bcryptService.hash(dto.newPassword);
+
+    const id = user.getId();
+    const role = user.getRole();
+    const email = user.getEmail();
+    // we need to generate new refresh and access token
+    const { accessToken, refreshToken } =
+      await this.tokenService.generateAuthToken({ id, email, role });
+
+    // we need to hash refresh token before save it  // securtiy concern
+    const hashedRefreshToken = await this.bcryptService.hash(refreshToken);
+
+    const finalUser = user
+      .withPassword(hashedPassword)
+      .updateRefreshToken(hashedRefreshToken)
+      .resetPasswordCodeFlag();
+
+    await this.userRepo.save(finalUser);
+
+    return {
+      ok: true,
+      value: {
+        user: finalUser,
+        accessToken,
+        refreshToken,
+      },
+    };
+  }
+}

--- a/src/module/auth/application/usecases/sign-in/sign-in.spec.ts
+++ b/src/module/auth/application/usecases/sign-in/sign-in.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('Sign in test cases', () => {
   let useCase: SignInUseCase;
   let userRepoMock: { findByEmail: jest.Mock; save: jest.Mock };
-  let bcryptServiceMock: { compare: jest.Mock };
+  let bcryptServiceMock: { compare: jest.Mock; hash: jest.Mock };
   let tokenServiceMock: { generate: jest.Mock };
   let configServiceMock: { getOrThrow: jest.Mock };
 
@@ -29,13 +29,15 @@ describe('Sign in test cases', () => {
       emailVerified: null,
       phone: null,
       refreshToken: null,
+      isPasswordCodeVerified: false,
+      passwordUpdatedAt: null,
       ...overrides,
     });
   };
 
   beforeEach(async () => {
     userRepoMock = { findByEmail: jest.fn(), save: jest.fn() };
-    bcryptServiceMock = { compare: jest.fn() };
+    bcryptServiceMock = { compare: jest.fn(), hash: jest.fn() };
     tokenServiceMock = { generate: jest.fn() };
     configServiceMock = { getOrThrow: jest.fn().mockReturnValue('secret') };
 

--- a/src/module/auth/application/usecases/sign-in/sign-in.usecase.ts
+++ b/src/module/auth/application/usecases/sign-in/sign-in.usecase.ts
@@ -17,7 +17,7 @@ import {
 @Injectable()
 export class SignInUseCase implements IUseCase<
   SignInParam,
-  Promise<Result<{ user: User; accessToken: string }>>
+  Promise<Result<{ user: User; accessToken: string; refreshToken: string }>>
 > {
   constructor(
     @Inject(IBCRYPT_SERVICE)
@@ -31,7 +31,9 @@ export class SignInUseCase implements IUseCase<
 
   async execute(
     dto: SignInParam,
-  ): Promise<Result<{ user: User; accessToken: string }>> {
+  ): Promise<
+    Result<{ user: User; accessToken: string; refreshToken: string }>
+  > {
     const userResult = await this.userRepo.findByEmail(dto.email);
 
     if (!userResult.ok) return userResult;
@@ -78,13 +80,15 @@ export class SignInUseCase implements IUseCase<
       { expiresIn: '7d', secret: refreshTokenSecret },
     );
 
-    const updatedUser = rawUser.updateRefreshToken(refreshToken);
+    const hashingRefreshToken = await this.bcrypteService.hash(refreshToken);
+
+    const updatedUser = rawUser.updateRefreshToken(hashingRefreshToken);
 
     await this.userRepo.save(updatedUser);
 
     return {
       ok: true,
-      value: { user: updatedUser, accessToken },
+      value: { user: updatedUser, accessToken, refreshToken },
     };
   }
 }

--- a/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.params.ts
+++ b/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.params.ts
@@ -1,0 +1,6 @@
+export class VerifyResetPasswordCodeParam {
+  constructor(
+    public readonly email: string,
+    public readonly code: string,
+  ) {}
+}

--- a/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.spec.ts
+++ b/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VerifyResetPasswordCodeUseCase } from './verify-reset-password-code.usecase';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import { IOTP_REPOSITORY } from '@/module/auth/domain/constants/injection.token';
+import { User } from '@/module/users/domain/entity/user.entity';
+import { UserRole } from '@/module/users/domain/interface/role.interface';
+import { createHash } from 'crypto';
+
+describe('Verify reset password test cases', () => {
+  let usecase: VerifyResetPasswordCodeUseCase;
+  let mockUserRepo: { findByEmail: jest.Mock; save: jest.Mock };
+  let mockOTPRepo: { getResetCode: jest.Mock; delResetCode: jest.Mock };
+
+  const createUser = (override?: Partial<any>) => {
+    return User.rehydrate({
+      email: 'test@example.com',
+      username: 'test',
+      id: 'user-123',
+      isPasswordCodeVerified: false,
+      password: 'hashed-pass',
+      emailVerified: null,
+      isVerified: true,
+      passwordUpdatedAt: null,
+      phone: null,
+      refreshToken: 'some-token',
+      role: 'Studen' as UserRole,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+      ...override,
+    });
+  };
+
+  beforeEach(async () => {
+    mockUserRepo = {
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+    };
+    mockOTPRepo = {
+      getResetCode: jest.fn(),
+      delResetCode: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VerifyResetPasswordCodeUseCase,
+        {
+          provide: IUSER_REPOSITORY,
+          useValue: mockUserRepo,
+        },
+        {
+          provide: IOTP_REPOSITORY,
+          useValue: mockOTPRepo,
+        },
+      ],
+    }).compile();
+
+    usecase = module.get<VerifyResetPasswordCodeUseCase>(
+      VerifyResetPasswordCodeUseCase,
+    );
+  });
+
+  it('should verify reset token if they matched', async () => {
+    const user = createUser();
+
+    const rawCode = '123456';
+
+    const expectedHash = createHash('sha256').update(rawCode).digest('hex');
+
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+    mockOTPRepo.getResetCode.mockResolvedValue({
+      ok: true,
+      value: expectedHash,
+    });
+
+    const result = await usecase.execute({
+      email: 'test@example.com',
+      code: rawCode,
+    });
+
+    expect(result.ok).toBeTruthy();
+    expect(mockUserRepo.save).toHaveBeenCalled();
+    expect(mockOTPRepo.delResetCode).toHaveBeenCalledWith(
+      `reset_password:${user.getId()}`,
+    );
+  });
+
+  it('should failed when saved code did not match provided code', async () => {
+    const user = createUser();
+    const rawCode = '775858';
+    const expectedHash = createHash('sha256').update(rawCode).digest('hex');
+    mockUserRepo.findByEmail.mockResolvedValue({ ok: true, value: user });
+    mockOTPRepo.getResetCode.mockResolvedValue({
+      ok: true,
+      value: expectedHash,
+    });
+
+    const result = await usecase.execute({
+      email: 'test@example.com',
+      code: '123456', // different code
+    });
+
+    expect(result.ok).toBe(false);
+    expect(mockOTPRepo.delResetCode).not.toHaveBeenCalled();
+    expect(mockUserRepo.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.usecase.ts
+++ b/src/module/auth/application/usecases/verify-reset-password-code/verify-reset-password-code.usecase.ts
@@ -1,0 +1,68 @@
+import { IUseCase } from '@/core/common/use-case-interface';
+import { VerifyResetPasswordCodeParam } from './verify-reset-password-code.params';
+import { Result } from '@core/common/result.pattern';
+import { Inject, Injectable } from '@nestjs/common';
+import { IUSER_REPOSITORY } from '@/module/users/domain/constants/injection.token';
+import type { IUserRepository } from '@/module/users/domain/repositories/user.repository.interface';
+import { IOTP_REPOSITORY } from '@/module/auth/domain/constants/injection.token';
+import type { IOTPRepository } from '@/module/auth/domain/repository/otp.repsoitory.interface';
+import { Errors, failure } from '@/core/common/err.utils';
+import { createHash } from 'crypto';
+type VRPCParams = VerifyResetPasswordCodeParam;
+
+@Injectable()
+export class VerifyResetPasswordCodeUseCase implements IUseCase<
+  VRPCParams,
+  Promise<Result<string>>
+> {
+  constructor(
+    @Inject(IUSER_REPOSITORY) private readonly userRepo: IUserRepository,
+    @Inject(IOTP_REPOSITORY) private readonly otpRepo: IOTPRepository,
+  ) {}
+
+  async execute(dto: VRPCParams): Promise<Result<string>> {
+    const userResult = await this.userRepo.findByEmail(dto.email);
+
+    if (!userResult.ok)
+      return failure(Errors.notFound('User with this email not found'));
+
+    const user = userResult.value;
+    // hashing code
+    const hashingCode = createHash('sha256').update(dto.code).digest('hex');
+
+    // get hashed code from redis
+    const savedCodeResult = await this.otpRepo.getResetCode(
+      `reset_password:${user.getId()}`,
+    );
+
+    if (!savedCodeResult.ok)
+      return failure(Errors.internal('Failed to retrive code'));
+
+    if (!savedCodeResult.value)
+      return failure(
+        Errors.internal('Verification code has expired or was never sent'),
+      );
+
+    if (hashingCode !== savedCodeResult.value)
+      return failure(Errors.validation('Invalid code or was never sent'));
+
+    // set code is verified
+    const verifyUser = user.markPasswordCodeVerified();
+
+    // we need to save this to db and delete saved code
+
+    try {
+      await Promise.all([
+        this.userRepo.save(verifyUser),
+        this.otpRepo.delResetCode(`reset_password:${verifyUser.getId()}`),
+      ]);
+
+      return {
+        ok: true,
+        value: 'Code verification done successfully',
+      };
+    } catch {
+      return failure(Errors.internal('Failed to save process'));
+    }
+  }
+}

--- a/src/module/auth/auth.module.ts
+++ b/src/module/auth/auth.module.ts
@@ -8,24 +8,42 @@ import {
   IBCRYPT_SERVICE,
   IEMAIL_SERVICE,
   IJWTTOKEN_SERVICE,
+  IOTP_REPOSITORY,
 } from './domain/constants/injection.token';
 import { JwtModule } from '@nestjs/jwt';
 import { UserModule } from '../users/user.module';
 import { EmailVerificationUseCase } from './application/usecases/email-verification/email-verification.usecase';
 import { RegisterationUseCase } from './application/usecases/registeration/registeration.usecase';
 import { NodemailerService } from './infrastructure/security/email.service';
+import { RedisOTPRepository } from './infrastructure/repository/redis-otp.repository';
+import { ResendVerificationCodeUseCase } from './application/usecases/resend-verification-code/resend-verification-code.usecase';
+import { ForgotPasswordUseCase } from './application/usecases/forgot-password/forgot-password.usecase';
+import { VerifyResetPasswordCodeUseCase } from './application/usecases/verify-reset-password-code/verify-reset-password-code.usecase';
+import { ResetPasswordUseCase } from './application/usecases/reset-password/reset-password.usecase';
+import { CqrsModule } from '@nestjs/cqrs';
+import { AuthSendEmail } from './application/usecases/event-handler/auth-email-handler';
+import { RefreshTokenUseCase } from './application/usecases/refresh-token/refresh-token.usecase';
 
 const useCases: Provider[] = [
   AuthFacade,
   SignInUseCase,
   EmailVerificationUseCase,
   RegisterationUseCase,
+  ResendVerificationCodeUseCase,
+  ForgotPasswordUseCase,
+  VerifyResetPasswordCodeUseCase,
+  ResetPasswordUseCase,
+  RefreshTokenUseCase,
+
+  // Domain event
+  AuthSendEmail,
 ];
 
 const infrastructure: Provider[] = [
   BcryptService,
   TokenService,
   NodemailerService,
+  RedisOTPRepository,
 
   {
     useExisting: BcryptService,
@@ -39,12 +57,16 @@ const infrastructure: Provider[] = [
     useExisting: NodemailerService,
     provide: IEMAIL_SERVICE,
   },
+  {
+    useExisting: RedisOTPRepository,
+    provide: IOTP_REPOSITORY,
+  },
 ];
 
 @Module({
   controllers: [AuthController],
   providers: [...useCases, ...infrastructure],
-  imports: [JwtModule.register({}), UserModule],
+  imports: [JwtModule.register({}), UserModule, CqrsModule],
   exports: [AuthFacade],
 })
 export class AuthModule {}

--- a/src/module/auth/domain/constants/injection.token.ts
+++ b/src/module/auth/domain/constants/injection.token.ts
@@ -1,3 +1,4 @@
 export const IBCRYPT_SERVICE = Symbol('IBcryptService');
 export const IJWTTOKEN_SERVICE = Symbol('IJWTTokenService');
 export const IEMAIL_SERVICE = Symbol('IEmailService');
+export const IOTP_REPOSITORY = Symbol('IOTPRepository');

--- a/src/module/auth/domain/events/registeration-code.requested.ts
+++ b/src/module/auth/domain/events/registeration-code.requested.ts
@@ -1,0 +1,7 @@
+export class RegisterationCodeRequedEvent {
+  readonly action = 'REGISTERATION';
+  constructor(
+    public readonly email: string,
+    public readonly code: string,
+  ) {}
+}

--- a/src/module/auth/domain/events/resend-verification-code-requested.event.ts
+++ b/src/module/auth/domain/events/resend-verification-code-requested.event.ts
@@ -1,0 +1,7 @@
+export class ResendVerificationCodeRequestedEvent {
+  readonly action = 'RESEND';
+  constructor(
+    public readonly email: string,
+    public readonly code: string,
+  ) {}
+}

--- a/src/module/auth/domain/events/reset-password-requested.event.ts
+++ b/src/module/auth/domain/events/reset-password-requested.event.ts
@@ -1,0 +1,7 @@
+export class ResetPasswordRequestedEvent {
+  readonly action = 'RESET';
+  constructor(
+    public readonly email: string,
+    public readonly code: string,
+  ) {}
+}

--- a/src/module/auth/domain/repository/otp.repsoitory.interface.ts
+++ b/src/module/auth/domain/repository/otp.repsoitory.interface.ts
@@ -1,0 +1,11 @@
+import { Result } from '@core/common/result.pattern';
+
+export interface IOTPRepository {
+  getResetCode: (key: string) => Promise<Result<string | null>>;
+  setResetCode: (
+    key: string,
+    code: string,
+    ttlSeconds: number,
+  ) => Promise<Result<void>>;
+  delResetCode: (key: string) => Promise<Result<void>>;
+}

--- a/src/module/auth/domain/service/bcrypt.service.interface.ts
+++ b/src/module/auth/domain/service/bcrypt.service.interface.ts
@@ -1,4 +1,4 @@
 export interface IBcryptService {
-  compare: (plainPassword: string, hashedPassword: string) => Promise<boolean>;
-  hash: (password: string) => Promise<string>;
+  compare: (plainText: string, hashedValue: string) => Promise<boolean>;
+  hash: (plainText: string) => Promise<string>;
 }

--- a/src/module/auth/domain/service/email.service.interface.ts
+++ b/src/module/auth/domain/service/email.service.interface.ts
@@ -1,3 +1,3 @@
 export class IEmailService {
-  send: (email: string, subject: string, content: string) => Promise<void>;
+  send: (to: string, subject: string, content: string) => Promise<void>;
 }

--- a/src/module/auth/domain/service/token.service.interface.ts
+++ b/src/module/auth/domain/service/token.service.interface.ts
@@ -1,9 +1,9 @@
 export interface IJWTTokenService {
+  generateAuthToken: (
+    payload: JwtPayload,
+  ) => Promise<{ accessToken: string; refreshToken: string }>;
   generate: (payload: JwtPayload, option: TokenOptions) => Promise<string>;
-  verify: <T extends JwtPayload>(
-    token: string,
-    options?: TokenOptions,
-  ) => Promise<T>;
+  verify: <T extends JwtPayload>(token: string, secret: string) => Promise<T>;
 }
 
 export interface TokenOptions {

--- a/src/module/auth/infrastructure/repository/redis-otp.repository.ts
+++ b/src/module/auth/infrastructure/repository/redis-otp.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { IOTPRepository } from '../../domain/repository/otp.repsoitory.interface';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import Redis from 'ioredis';
+import { Result } from '@core/common/result.pattern';
+import { Errors, failure } from '@/core/common/err.utils';
+
+@Injectable()
+export class RedisOTPRepository implements IOTPRepository {
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  async getResetCode(key: string): Promise<Result<string | null>> {
+    try {
+      const result = await this.redis.get(key);
+      return {
+        ok: true,
+        value: result,
+      };
+    } catch {
+      return failure(Errors.internal('Redis connection failed'));
+    }
+  }
+
+  async setResetCode(
+    key: string,
+    code: string,
+    ttlSeconds: number,
+  ): Promise<Result<void>> {
+    try {
+      await this.redis.set(key, code, 'EX', ttlSeconds);
+      return {
+        ok: true,
+        value: undefined,
+      };
+    } catch {
+      return failure(Errors.internal('Redis connection failed'));
+    }
+  }
+
+  async delResetCode(key: string): Promise<Result<void>> {
+    try {
+      await this.redis.del(key);
+      return {
+        ok: true,
+        value: undefined,
+      };
+    } catch {
+      return failure(Errors.internal('Redis connection failed'));
+    }
+  }
+}

--- a/src/module/auth/infrastructure/security/bcrypt.service.ts
+++ b/src/module/auth/infrastructure/security/bcrypt.service.ts
@@ -9,11 +9,12 @@ export class BcryptService implements IBcryptService {
   constructor(private readonly config: ConfigService) {
     this.saltNumber = this.config.getOrThrow<number>('SALT_NUMBER');
   }
+
   async compare(plainPassword: string, hashedPassword: string) {
     return bcrypt.compare(plainPassword, hashedPassword);
   }
 
   async hash(password: string) {
-    return bcrypt.hash(password, this.saltNumber);
+    return bcrypt.hash(password, Number(this.saltNumber));
   }
 }

--- a/src/module/auth/infrastructure/security/email.service.ts
+++ b/src/module/auth/infrastructure/security/email.service.ts
@@ -10,8 +10,8 @@ export class NodemailerService implements IEmailService {
       host: process.env.MAIL_HOST,
       port: Number(process.env.EMAIL_PORT),
       auth: {
-        user: process.env.Email_USER,
-        pass: process.env.Email_PASS,
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
       },
     });
   }

--- a/src/module/auth/infrastructure/security/jwt.token.service.ts
+++ b/src/module/auth/infrastructure/security/jwt.token.service.ts
@@ -5,9 +5,13 @@ import {
   TokenOptions,
 } from '../../domain/service/token.service.interface';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class TokenService implements IJWTTokenService {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly config: ConfigService,
+  ) {}
 
   async generate(payload: JwtPayload, option: TokenOptions) {
     return this.jwtService.signAsync(payload, option as JwtSignOptions);
@@ -15,8 +19,28 @@ export class TokenService implements IJWTTokenService {
 
   async verify<T extends JwtPayload>(
     token: string,
-    options?: TokenOptions,
+    secret?: string,
   ): Promise<T> {
-    return this.jwtService.verifyAsync(token, options);
+    return await this.jwtService.verify(token, { secret });
+  }
+
+  async generateAuthToken(
+    payload: JwtPayload,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const [accessToken, refreshToken] = await Promise.all([
+      this.generate(payload, {
+        secret: this.config.getOrThrow<string>('JWT_ACCESS_TOKEN_SECRET'),
+        expiresIn: '15min',
+      }),
+      this.generate(payload, {
+        secret: this.config.getOrThrow<string>('JWT_REFRESH_TOKEN_SECRET'),
+        expiresIn: '7d',
+      }),
+    ]);
+
+    return {
+      accessToken,
+      refreshToken,
+    };
   }
 }

--- a/src/module/auth/presentation/auth.controller.ts
+++ b/src/module/auth/presentation/auth.controller.ts
@@ -1,18 +1,176 @@
-import { Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Patch,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
 import { AuthFacade } from '../application/auth.facade';
 import { SignInDto } from './dto/sign-in.dto';
 import { DomainException } from '@/core/common/filters/domain.exception';
+import { SignUpDto } from './dto/sign-up.dto';
+import { EmailVerification } from './dto/email-verification.dto';
+import { ResendCode } from './dto/resend-code.dto';
+import { AuthResponse } from './dto/auth.response';
+import { ForgotPassword } from './dto/forgot-password.dto';
+import { VerifyPasswordResetCode } from './dto/verify-reset-code.dto';
+import { ResetPassword } from './dto/reset-password.dto';
+import type { Request, Response } from 'express';
+import { Errors } from '@/core/common/err.utils';
+import { ConfigService } from '@nestjs/config';
 
-@Controller()
+@Controller('auth')
 export class AuthController {
-  constructor(private readonly authFacade: AuthFacade) {}
+  readonly SEVEN_DAYS = 24 * 7 * 60 * 60 * 1000;
+  readonly PATH = '/api/auth/refresh';
 
-  @Post()
-  async singIn(dto: SignInDto) {
+  constructor(
+    private readonly authFacade: AuthFacade,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Post('/signin')
+  @HttpCode(200)
+  async singIn(
+    @Body() dto: SignInDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const result = await this.authFacade.SignIn.execute(dto);
 
     if (!result.ok) throw new DomainException(result.error);
 
-    return result.value; // this return user entity / and access token
+    const { accessToken, refreshToken, user } = result.value;
+
+    this._setCookie(res, refreshToken);
+
+    // this return user entity / and access token
+    return {
+      user: AuthResponse.from(user),
+      accessToken: accessToken,
+    };
+  }
+
+  @Post('/signup')
+  async signUp(@Body() dto: SignUpDto) {
+    const result = await this.authFacade.signup.execute(dto);
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    return {
+      ok: true,
+      value: result.value,
+    };
+  }
+
+  @Post('email-verify')
+  async EmailVerification(
+    @Res({ passthrough: true }) res: Response,
+    @Req() req: Request,
+    @Body() dto: EmailVerification,
+  ) {
+    const result = await this.authFacade.emailVerification.execute(dto);
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    const { accessToken, refreshToken, user } = result.value;
+
+    this._setCookie(res, refreshToken);
+
+    return {
+      user: AuthResponse.from(user),
+      accessToken: accessToken,
+    };
+  }
+
+  @Post('resend-code')
+  async ResendCodeVerificaion(@Body() dto: ResendCode) {
+    const result = await this.authFacade.resendCode.execute({
+      email: dto.email,
+    });
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    return {
+      message: result.value,
+    };
+  }
+
+  @Post('forgot-password')
+  async ForgotPassword(@Body() dto: ForgotPassword) {
+    const result = await this.authFacade.forgorPassword.execute(dto);
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    return {
+      message: result.value,
+    };
+  }
+
+  @Post('verify-resetcode')
+  async VerifyPasswordResetCode(@Body() dto: VerifyPasswordResetCode) {
+    const result = await this.authFacade.verifyResetCode.execute(dto);
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    return {
+      message: result.value,
+    };
+  }
+
+  @Patch('reset-password')
+  async resetPassword(
+    @Body() dto: ResetPassword,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.authFacade.resetPassword.execute(dto);
+
+    if (!result.ok) throw new DomainException(result.error);
+
+    const { accessToken, refreshToken, user } = result.value;
+
+    // set refreshToken to cookies
+    this._setCookie(res, refreshToken);
+
+    return {
+      user: AuthResponse.from(user),
+      accessToken: accessToken,
+    };
+  }
+
+  @Post('refresh')
+  @HttpCode(200)
+  async RefreshToken(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const oldToken = req.cookies?.['refreshToken'] as string | undefined;
+
+    if (!oldToken)
+      throw new DomainException(Errors.notFound('No refresh token found'));
+
+    const result = await this.authFacade.refreshToken.execute(oldToken);
+
+    if (!result.ok) {
+      res.clearCookie('refreshToken', { path: this.PATH });
+      throw new DomainException(result.error);
+    }
+
+    const { accessToken, refreshToken } = result.value;
+
+    this._setCookie(res, refreshToken);
+
+    return { accessToken };
+  }
+
+  private _setCookie(res: Response, tokenValue: string) {
+    res.cookie('refreshToken', tokenValue, {
+      httpOnly: true,
+      path: this.PATH,
+      maxAge: this.SEVEN_DAYS,
+      sameSite: 'strict',
+      secure: this.config.getOrThrow<string>('NODE_ENV') === 'prod',
+    });
   }
 }

--- a/src/module/auth/presentation/dto/auth.response.ts
+++ b/src/module/auth/presentation/dto/auth.response.ts
@@ -1,0 +1,19 @@
+import { User } from '@/module/users/domain/entity/user.entity';
+
+export class AuthResponse {
+  constructor() {}
+
+  static from(user: User) {
+    return {
+      id: user.getId(),
+      username: user.getUsername(),
+      role: user.getRole(),
+      email: user.getEmail(),
+      createdAt: user.getCreatedAt(),
+      updatedAt: user.getUpdatedAt(),
+      isVerified: user.getIsVerified(),
+      emailVerified: user.getEmailVerified(),
+      phone: user.getPhone(),
+    };
+  }
+}

--- a/src/module/auth/presentation/dto/email-verification.dto.ts
+++ b/src/module/auth/presentation/dto/email-verification.dto.ts
@@ -1,0 +1,18 @@
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class EmailVerification {
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(6)
+  @MinLength(6)
+  code: string;
+
+  @IsEmail()
+  email: string;
+}

--- a/src/module/auth/presentation/dto/forgot-password.dto.ts
+++ b/src/module/auth/presentation/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class ForgotPassword {
+  @IsEmail()
+  email: string;
+}

--- a/src/module/auth/presentation/dto/resend-code.dto.ts
+++ b/src/module/auth/presentation/dto/resend-code.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class ResendCode {
+  @IsString()
+  @IsEmail()
+  email: string;
+}

--- a/src/module/auth/presentation/dto/reset-password.dto.ts
+++ b/src/module/auth/presentation/dto/reset-password.dto.ts
@@ -1,0 +1,16 @@
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class ResetPassword {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MaxLength(20)
+  @MinLength(6)
+  newPassword: string;
+
+  // build decorator
+
+  @IsString()
+  confirmPassword: string;
+}

--- a/src/module/auth/presentation/dto/sign-up.dto.ts
+++ b/src/module/auth/presentation/dto/sign-up.dto.ts
@@ -1,0 +1,17 @@
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class SignUpDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsString()
+  username: string;
+}

--- a/src/module/auth/presentation/dto/verify-reset-code.dto.ts
+++ b/src/module/auth/presentation/dto/verify-reset-code.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class VerifyPasswordResetCode {
+  @IsEmail()
+  email: string;
+  @IsString()
+  @MaxLength(6)
+  @MinLength(6)
+  code: string;
+}


### PR DESCRIPTION
# Auth Module Refactor

## 🚀 Key Changes
* **Infrastructure Shift:** Migrated from direct `ioredis` usage to a domain-driven `IOTP_REPOSITORY` abstraction for handling codes (OTP/Reset).
* **Event-Driven Architecture:** Replaced direct `EmailService` calls with a CQRS `EventBus` and a dedicated `AuthSendEmail` handler for asynchronous email delivery.
* **Refresh Token Rotation:** Implemented a full `RefreshTokenUseCase` with token hashing in the database and automatic session invalidation if a token mismatch is detected (security enhancement).
* **Security & Validation:** * Added a 30-minute cooldown period for password resets.
    * Added `refreshToken` to the successful `EmailVerification` response.
    * Standardized error handling using the `failure(Errors.internal(...))` pattern.

---

## 🛠 Updated Logic & Architecture

### 1. Refactored Use Cases
* **EmailVerification:** Now retrieves codes via `otpRepo` and returns both `accessToken` and `refreshToken`.
* **ForgotPassword:** Checks `passwordUpdatedAt` to prevent spamming. Instead of sending email directly, it publishes a `ResetPasswordRequestedEvent`.
* **Registeration:** Now uses `hashService` (renamed from `hash`) and delegating the OTP storage and email notification to the repository and event bus respectively.

### 2. New Components
* **RefreshTokenUseCase:** * Verifies the old refresh token against a secret.
    * Compares the provided token with the hashed version in the DB.
    * If they don't match, it wipes the DB token (detecting potential theft) and fails.
    * If matched, generates a new pair (Rotation).
* **AuthSendEmail Handler:** A central CQRS handler that listens for `RegisterationCodeRequedEvent`, `ResendVerificationCodeRequestedEvent`, and `ResetPasswordRequestedEvent` to send localized emails.

### 3. Interface Changes
* **AuthFacade:** Updated to include the new `refreshToken` use case.
* **Mocks/Tests:** All test suites (`.spec.ts`) updated to reflect the transition from `mockRedis` to `mockOTPRepo` and `mockEmail` to `mockEventPublisher`.

---

## 📝 Code Snapshot: Refresh Token Logic
```typescript
// Core logic for the new rotation strategy
const isTokensMatched = hashedTokenInDb 
  ? await this.bcryptService.compare(oldRefreshToken, hashedTokenInDb) 
  : false;

if (!isTokensMatched) {
  await this.userRepo.save(user.updateRefreshToken(null)); // Invalidate session
  return failure(Errors.unauthroized('Session expired or compromised'));
}