### PR TITLE
add notificaion sys

### DIFF
--- a/src/module/notification/application/mapper/notification.mapper.ts
+++ b/src/module/notification/application/mapper/notification.mapper.ts
@@ -1,0 +1,23 @@
+import { ApiPaginateResponse } from '@/core';
+import { Notification } from '../../domain/entity/notification.entity';
+
+export class NotificationMapper {
+  private constructor() {}
+
+  static toResponse(this: void, notification: Notification) {
+    return {
+      id: notification.getId,
+      text: notification.getText,
+      title: notification.getTitle,
+      read: notification.getRead,
+      createdAt: notification.getCreatedAt,
+    };
+  }
+}
+
+export type NotificationResponse = ReturnType<
+  typeof NotificationMapper.toResponse
+>;
+
+export type NotificationPaginationResponse =
+  ApiPaginateResponse<NotificationResponse>;

--- a/src/module/notification/application/services/course-purchased.dispatcher.ts
+++ b/src/module/notification/application/services/course-purchased.dispatcher.ts
@@ -1,0 +1,25 @@
+import { CoursePurchasedEvent } from '@/module/courses/domain/events/course-purchased.event';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { type INotificationSystemRepository } from '../../domain/repository/notification.repository.interface';
+import { NotificationDispatcher } from './notification.dispatcher';
+import { Notification } from '../../domain/entity/notification.entity';
+
+@EventsHandler(CoursePurchasedEvent)
+export class CoursePurchasedDispatcher implements IEventHandler<CoursePurchasedEvent> {
+  constructor(
+    private readonly notifyRepo: INotificationSystemRepository,
+    private readonly dispatcher: NotificationDispatcher,
+  ) {}
+
+  async handle(event: CoursePurchasedEvent) {
+    const notification = Notification.create({
+      userId: event.userId,
+      title: 'Purchase Successful!',
+      text: `You are enrolled in ${event.courseName}`,
+    });
+
+    await this.notifyRepo.save(notification);
+    // real time connection
+    this.dispatcher.send(notification);
+  }
+}

--- a/src/module/notification/application/services/notification.dispatcher.ts
+++ b/src/module/notification/application/services/notification.dispatcher.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { Notification } from '../../domain/entity/notification.entity';
+import { NotificationGateWay } from '../../infrastructure/getaway/notification.gateway';
+
+@Injectable()
+export class NotificationDispatcher {
+  constructor(private readonly gateway: NotificationGateWay) {}
+  send(notification: Notification) {
+    this.gateway.pushToUser(notification.getUserId, {
+      id: notification.getId,
+      userId: notification.getUserId,
+      text: notification.getText,
+      title: notification.getTitle,
+      isDeleted: notification.getIsDeleted,
+      createdAt: notification.getCreatedAt,
+      read: notification.getRead,
+    });
+  }
+}

--- a/src/module/notification/application/usecases/delete-multiple-notifications/delete-multiple-notifications.usecase.ts
+++ b/src/module/notification/application/usecases/delete-multiple-notifications/delete-multiple-notifications.usecase.ts
@@ -1,0 +1,21 @@
+import { Errors, IUseCase, Result } from '@/core';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DeleteMultipleNotificationUseCase implements IUseCase<
+  string[],
+  Promise<Result<void>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(params: string[]): Promise<Result<void>> {
+    if (!params || !params.length)
+      return Result.fail(Errors.validation('No notification IDs provided'));
+    return await this.notificationRepo.deleteAll(params);
+  }
+}

--- a/src/module/notification/application/usecases/delete-notification/delete-notification.usecase.ts
+++ b/src/module/notification/application/usecases/delete-notification/delete-notification.usecase.ts
@@ -1,0 +1,20 @@
+import { IUseCase, Result } from '@/core';
+import { Inject, Injectable } from '@nestjs/common';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+
+@Injectable()
+export class DeleteNotificationUsecase implements IUseCase<
+  string,
+  Promise<Result<void>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(id: string): Promise<Result<void>> {
+    await this.notificationRepo.delete(id);
+    return Result.ok(undefined);
+  }
+}

--- a/src/module/notification/application/usecases/get-user-notification/get-user-notification.usecase.ts
+++ b/src/module/notification/application/usecases/get-user-notification/get-user-notification.usecase.ts
@@ -1,0 +1,31 @@
+import { IUseCase, Result } from '@/core';
+import {
+  NotificationMapper,
+  NotificationResponse,
+} from '../../mapper/notification.mapper';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { Inject, Injectable } from '@nestjs/common';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+
+@Injectable()
+export class GetUserNotificationUseCase implements IUseCase<
+  string,
+  Promise<Result<NotificationResponse>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(id: string): Promise<Result<NotificationResponse>> {
+    const notificationResult = await this.notificationRepo.findById(id);
+
+    if (!notificationResult.ok) return notificationResult;
+
+    const notification = notificationResult.value;
+
+    const reponse = NotificationMapper.toResponse(notification);
+
+    return Result.ok(reponse);
+  }
+}

--- a/src/module/notification/application/usecases/get-user-notifications/get-user-notification.usecase.ts
+++ b/src/module/notification/application/usecases/get-user-notifications/get-user-notification.usecase.ts
@@ -1,0 +1,38 @@
+import { IUseCase, ResponseBuilder, Result } from '@/core';
+import {
+  NotificationMapper,
+  NotificationPaginationResponse,
+} from '../../mapper/notification.mapper';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { NotificationPaginationResult } from '@/module/notification/domain/entity/notification.type';
+import { Inject, Injectable } from '@nestjs/common';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+
+@Injectable()
+export class GetUserNotificationsUseCase implements IUseCase<
+  NotificationPaginationResult,
+  Promise<Result<NotificationPaginationResponse>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(
+    params: NotificationPaginationResult,
+  ): Promise<Result<NotificationPaginationResponse>> {
+    const notificationResult = await this.notificationRepo.findAll(params);
+
+    if (!notificationResult.ok) return notificationResult;
+
+    const { data, meta } = notificationResult.value;
+
+    const reponse = ResponseBuilder.paginateMapped(
+      data,
+      meta,
+      NotificationMapper.toResponse,
+    );
+
+    return Result.ok(reponse);
+  }
+}

--- a/src/module/notification/application/usecases/notification.facade.ts
+++ b/src/module/notification/application/usecases/notification.facade.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { GetUserNotificationUseCase } from './get-user-notification/get-user-notification.usecase';
+import { GetUserNotificationsUseCase } from './get-user-notifications/get-user-notification.usecase';
+import { DeleteNotificationUsecase } from './delete-notification/delete-notification.usecase';
+import { DeleteMultipleNotificationUseCase } from './delete-multiple-notifications/delete-multiple-notifications.usecase';
+import { UpdateNotificationUseCase } from './update-notification/update-notification.usecase';
+import { UpdateNotificationsUseCase } from './update-notifications/update-notifications.usecase';
+
+@Injectable()
+export class NotificationFacade {
+  constructor(
+    public readonly getNotification: GetUserNotificationUseCase,
+    public readonly getNotifications: GetUserNotificationsUseCase,
+    public readonly deleteOne: DeleteNotificationUsecase,
+    public readonly deleteAll: DeleteMultipleNotificationUseCase,
+    public readonly updateNotification: UpdateNotificationUseCase,
+    public readonly updateNotifications: UpdateNotificationsUseCase,
+  ) {}
+}

--- a/src/module/notification/application/usecases/update-notification/update-notification.usecase.ts
+++ b/src/module/notification/application/usecases/update-notification/update-notification.usecase.ts
@@ -1,0 +1,39 @@
+import { Errors, IUseCase, Result } from '@/core';
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  NotificationMapper,
+  NotificationResponse,
+} from '../../mapper/notification.mapper';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+
+@Injectable()
+export class UpdateNotificationUseCase implements IUseCase<
+  string,
+  Promise<Result<NotificationResponse>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(id: string): Promise<Result<NotificationResponse>> {
+    const NotificationResult = await this.notificationRepo.findById(id);
+
+    if (!NotificationResult.ok)
+      return Result.fail(Errors.notFound('Notification not found'));
+
+    const notification = NotificationResult.value;
+
+    const markAsRead = notification.markAsRead();
+
+    const updateInDb = await this.notificationRepo.save(markAsRead);
+
+    if (!updateInDb.ok)
+      return Result.fail(Errors.internal('Update in notification failed'));
+
+    const response = NotificationMapper.toResponse(notification);
+
+    return Result.ok(response);
+  }
+}

--- a/src/module/notification/application/usecases/update-notifications/update-notifications.usecase.ts
+++ b/src/module/notification/application/usecases/update-notifications/update-notifications.usecase.ts
@@ -1,0 +1,22 @@
+import { Errors, IUseCase, Result } from '@/core';
+import { INOTIFICATION_REPOSITORY } from '@/module/notification/domain/constant/injection.token';
+import { type INotificationSystemRepository } from '@/module/notification/domain/repository/notification.repository.interface';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UpdateNotificationsUseCase implements IUseCase<
+  string[],
+  Promise<Result<void>>
+> {
+  constructor(
+    @Inject(INOTIFICATION_REPOSITORY)
+    private readonly notificationRepo: INotificationSystemRepository,
+  ) {}
+
+  async execute(params: string[]): Promise<Result<void>> {
+    if (!params || params.length)
+      return Result.fail(Errors.validation('No notification IDs provided'));
+
+    return await this.notificationRepo.markAllAsRead(params);
+  }
+}

--- a/src/module/notification/domain/constant/injection.token.ts
+++ b/src/module/notification/domain/constant/injection.token.ts
@@ -1,0 +1,1 @@
+export const INOTIFICATION_REPOSITORY = Symbol('INotificationSystemRepository');

--- a/src/module/notification/domain/entity/notification.entity.ts
+++ b/src/module/notification/domain/entity/notification.entity.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from 'crypto';
+import { NotificationState } from './notification.type';
+
+export class Notification {
+  private constructor(private readonly props: NotificationState) {}
+
+  public get getId(): string {
+    return this.props.id;
+  }
+
+  public get getTitle(): string {
+    return this.props.title;
+  }
+
+  public get getText(): string {
+    return this.props.text;
+  }
+
+  public get getRead(): boolean {
+    return this.props.read;
+  }
+
+  public get getCreatedAt(): Date {
+    return this.props.createdAt;
+  }
+
+  public get getUserId(): string {
+    return this.props.userId;
+  }
+
+  public get getIsDeleted(): boolean {
+    return this.props.isDeleted;
+  }
+
+  public withTitle(title: string): Notification {
+    if (!title && title.trim() == '') throw new Error('Title is required');
+    title = title.trim();
+    return this._copy({ title });
+  }
+
+  public setUserId(userId: string): Notification {
+    const trimmedId = userId?.trim();
+    if (!trimmedId || !this._isValidId(trimmedId))
+      throw new Error('User id not valid');
+
+    return this._copy({ userId: trimmedId });
+  }
+
+  public withText(text: string): Notification {
+    if (!text && text.trim() == '') throw new Error('text is required');
+    text = text.trim();
+    return this._copy({ text });
+  }
+
+  markAsDeleted(): Notification {
+    return this._copy({ isDeleted: false });
+  }
+
+  public markAsRead(): Notification {
+    return this._copy({ read: true });
+  }
+
+  public static create(
+    props: Pick<NotificationState, 'text' | 'title' | 'userId'>,
+  ): Notification {
+    return new Notification({
+      id: randomUUID(),
+      createdAt: new Date(),
+      read: false,
+      text: props.text,
+      title: props.title,
+      userId: props.userId,
+      isDeleted: false,
+    });
+  }
+
+  public static rehydrate(props: NotificationState): Notification {
+    return new Notification(props);
+  }
+
+  public toPersistence() {
+    return {
+      id: this.props.id,
+      userId: this.props.userId,
+      text: this.props.text,
+      title: this.props.title,
+      read: this.props.read,
+      createdAt: this.props.createdAt,
+      isDeleted: false,
+    };
+  }
+
+  private _copy(props?: Partial<NotificationState>): Notification {
+    return new Notification({ ...this.props, ...props });
+  }
+
+  private _isValidId(id: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      id,
+    );
+  }
+}

--- a/src/module/notification/domain/entity/notification.type.ts
+++ b/src/module/notification/domain/entity/notification.type.ts
@@ -1,0 +1,15 @@
+import { PaginationParams } from '@/core';
+
+export interface NotificationState {
+  readonly id: string;
+  readonly title: string;
+  readonly text: string;
+  readonly read: boolean;
+  readonly createdAt: Date;
+  readonly userId: string;
+  readonly isDeleted: boolean;
+}
+
+export interface NotificationPaginationResult extends PaginationParams {
+  readonly userId: string;
+}

--- a/src/module/notification/domain/repository/notification.repository.interface.ts
+++ b/src/module/notification/domain/repository/notification.repository.interface.ts
@@ -1,0 +1,21 @@
+import { PaginationResult, Result } from '@core/index';
+import { NotificationPaginationResult } from '../entity/notification.type';
+import { Notification } from '../entity/notification.entity';
+
+export interface INotificationSystemRepository {
+  findAll: (
+    params: NotificationPaginationResult,
+  ) => Promise<Result<PaginationResult<Notification>>>;
+
+  findById: (id: string) => Promise<Result<Notification>>;
+
+  // update all messages as read
+  markAllAsRead: (ids: string[]) => Promise<Result<void>>;
+
+  save: (notification: Notification) => Promise<Result<Notification>>;
+  // soft deletion
+  delete: (id: string) => Promise<Result<void>>;
+
+  // delete all messages
+  deleteAll: (ids: string[]) => Promise<Result<void>>;
+}

--- a/src/module/notification/infrastructure/getaway/notification.gateway.ts
+++ b/src/module/notification/infrastructure/getaway/notification.gateway.ts
@@ -1,0 +1,16 @@
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+@WebSocketGateway({ namespace: 'notification', cors: true })
+export class NotificationGateWay {
+  @WebSocketServer() server!: Server;
+
+  async handleConnection(client: Socket) {
+    const userId = client.handshake.query.userId as string;
+    if (userId) await client.join(userId);
+  }
+
+  pushToUser(userId: string, notification: any) {
+    this.server.to(userId).emit('new-message', notification);
+  }
+}

--- a/src/module/notification/infrastructure/mapper/notification.mapper.ts
+++ b/src/module/notification/infrastructure/mapper/notification.mapper.ts
@@ -1,0 +1,8 @@
+import { Notification as PrismaNotificaion } from '@prisma/client';
+import { Notification } from '../../domain/entity/notification.entity';
+export class NotificationMapper {
+  private constructor() {}
+  static toDomain(rawNotification: PrismaNotificaion) {
+    return Notification.rehydrate(rawNotification);
+  }
+}

--- a/src/module/notification/infrastructure/notification.prisma.repository.ts
+++ b/src/module/notification/infrastructure/notification.prisma.repository.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { INotificationSystemRepository } from '../domain/repository/notification.repository.interface';
+import {
+  ErrorMapper,
+  Errors,
+  paginate,
+  PaginationResult,
+  PrismaService,
+  Result,
+} from '@/core';
+import { TransactionContext } from '@/core/common/infrastructure/http/transaction/transaction.context';
+import { NotificationPaginationResult } from '../domain/entity/notification.type';
+import { Prisma } from '@prisma/client';
+import { NotificationMapper } from './mapper/notification.mapper';
+import { Notification } from '../domain/entity/notification.entity';
+import { Notification as PrismaNotification } from '@prisma/client';
+
+@Injectable()
+export class NotificationPrismaRepository implements INotificationSystemRepository {
+  private readonly _entityName = 'Notification';
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly context: TransactionContext,
+  ) {}
+
+  private get _db() {
+    const store = this.context.getStore();
+    return store?.tx || this.prisma;
+  }
+
+  async findAll(
+    params: NotificationPaginationResult,
+  ): Promise<Result<PaginationResult<Notification>>> {
+    try {
+      const { userId, page, limit } = params;
+      const where: Prisma.NotificationWhereInput = {
+        ...(userId && { userId }),
+        isDeleted: false,
+      };
+
+      const paginateData = paginate(
+        { limit, page },
+        (args) =>
+          this._db.notification.findMany({
+            ...args,
+            where,
+            orderBy: { createdAt: 'desc' },
+          }),
+        (args) => this._db.notification.count({ ...args, where }),
+        (row) => NotificationMapper.toDomain(row),
+      );
+
+      return paginateData;
+    } catch (err: unknown) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
+  async findById(id: string): Promise<Result<Notification>> {
+    try {
+      const result = await this._db.notification.findUnique({ where: { id } });
+
+      if (!result)
+        return Result.fail(Errors.notFound('Notification not exists'));
+
+      const toDomain = NotificationMapper.toDomain(result);
+      return Result.ok(toDomain);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
+  async markAllAsRead(ids: string[]): Promise<Result<void>> {
+    try {
+      const result = await this._db.notification.updateManyAndReturn({
+        where: {
+          id: {
+            in: ids,
+          },
+        },
+        data: { read: true },
+      });
+
+      if (!result) return Result.fail(Errors.internal('Fail to update data'));
+
+      return Result.ok(undefined);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
+  async save(notification: Notification): Promise<Result<Notification>> {
+    try {
+      const data: PrismaNotification = await this._db.notification.upsert({
+        where: { id: notification.getId },
+        create: notification.toPersistence(),
+        update: notification.toPersistence(),
+      });
+
+      const toDomain = NotificationMapper.toDomain(data);
+
+      return Result.ok(toDomain);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
+  async deleteAll(ids: string[]): Promise<Result<void>> {
+    try {
+      const result = await this._db.notification.deleteMany({
+        where: {
+          id: {
+            in: ids,
+          },
+        },
+      });
+
+      if (!result.count)
+        return Result.fail(Errors.internal('Faild to delete notifications'));
+
+      return Result.ok(undefined);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
+  async delete(id: string): Promise<Result<void>> {
+    try {
+      const result = await this._db.notification.update({
+        where: { id },
+        data: { isDeleted: true },
+      });
+
+      if (!result) return Result.fail(Errors.internal('Deleted failed'));
+      return Result.ok(undefined);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+}

--- a/src/module/notification/notification.module.ts
+++ b/src/module/notification/notification.module.ts
@@ -1,0 +1,39 @@
+import { Module, Provider } from '@nestjs/common';
+import { GetUserNotificationUseCase } from './application/usecases/get-user-notification/get-user-notification.usecase';
+import { GetUserNotificationsUseCase } from './application/usecases/get-user-notifications/get-user-notification.usecase';
+import { DeleteNotificationUsecase } from './application/usecases/delete-notification/delete-notification.usecase';
+import { DeleteMultipleNotificationUseCase } from './application/usecases/delete-multiple-notifications/delete-multiple-notifications.usecase';
+import { UpdateNotificationUseCase } from './application/usecases/update-notification/update-notification.usecase';
+import { UpdateNotificationsUseCase } from './application/usecases/update-notifications/update-notifications.usecase';
+import { NotificationFacade } from './application/usecases/notification.facade';
+import { NotificationPrismaRepository } from './infrastructure/notification.prisma.repository';
+import { INOTIFICATION_REPOSITORY } from './domain/constant/injection.token';
+import { NotificationController } from './presentation/notification.controller';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule } from '@nestjs/config';
+
+const usecases: Provider[] = [
+  GetUserNotificationUseCase,
+  GetUserNotificationsUseCase,
+  DeleteNotificationUsecase,
+  DeleteMultipleNotificationUseCase,
+  UpdateNotificationUseCase,
+  UpdateNotificationsUseCase,
+  NotificationFacade,
+];
+
+const infrastructure: Provider[] = [
+  NotificationPrismaRepository,
+  {
+    provide: INOTIFICATION_REPOSITORY,
+    useClass: NotificationPrismaRepository,
+  },
+];
+
+@Module({
+  exports: [],
+  imports: [JwtModule, ConfigModule],
+  controllers: [NotificationController],
+  providers: [...usecases, ...infrastructure],
+})
+export class NotificationModule {}

--- a/src/module/notification/presentation/dto/notification.id.dto.ts
+++ b/src/module/notification/presentation/dto/notification.id.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class NotificationIdDto {
+  @IsUUID()
+  id!: string;
+}

--- a/src/module/notification/presentation/dto/notification.ids.dto.ts
+++ b/src/module/notification/presentation/dto/notification.ids.dto.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsUUID } from 'class-validator';
+
+export class NotificationIdsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsUUID('4', { each: true }) // uuid- version 4
+  ids!: string[];
+}

--- a/src/module/notification/presentation/dto/pagination.notification.dto.ts
+++ b/src/module/notification/presentation/dto/pagination.notification.dto.ts
@@ -1,0 +1,11 @@
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class QueryPaginationNotification {
+  @IsOptional()
+  @IsNumber()
+  page?: number;
+
+  @IsOptional()
+  @IsNumber()
+  limit?: number;
+}

--- a/src/module/notification/presentation/notification.controller.ts
+++ b/src/module/notification/presentation/notification.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { NotificationFacade } from '../application/usecases/notification.facade';
+import { VerifyJwt } from '@/core';
+import { JwtPayload } from '@/module/auth';
+import { QueryPaginationNotification } from './dto/pagination.notification.dto';
+import { NotificationIdDto } from './dto/notification.id.dto';
+import { NotificationIdsDto } from './dto/notification.ids.dto';
+
+@UseGuards(VerifyJwt)
+@Controller('notifications')
+export class NotificationController {
+  constructor(private readonly notificationFacade: NotificationFacade) {}
+
+  @Get()
+  async findAll(
+    @Req() request: Request,
+    @Query() query: QueryPaginationNotification,
+  ) {
+    const { id: userId } = request['user'] as JwtPayload;
+
+    return await this.notificationFacade.getNotifications.execute({
+      ...query,
+      userId,
+    });
+  }
+
+  @Get(':id')
+  async findOne(@Query() dto: NotificationIdDto) {
+    return await this.notificationFacade.getNotification.execute(dto.id);
+  }
+
+  @Patch('update')
+  async updateOne(@Body() dto: NotificationIdDto) {
+    return await this.notificationFacade.updateNotification.execute(dto.id);
+  }
+
+  @Patch('update-all')
+  async updateAll(@Body() dto: NotificationIdsDto) {
+    return await this.notificationFacade.updateNotifications.execute(dto.ids);
+  }
+
+  @Delete('delete')
+  async delete(@Query() dto: NotificationIdDto) {
+    return await this.notificationFacade.deleteOne.execute(dto.id);
+  }
+
+  @Delete('delete-many')
+  async deleteMany(@Body() dto: NotificationIdsDto) {
+    return await this.notificationFacade.deleteAll.execute(dto.ids);
+  }
+}


### PR DESCRIPTION
# 📬 Notification Module — Summary

## 🆕 New Feature: Notification System
A complete notification module was introduced with support for:
- Real-time delivery (WebSocket)
- Persistence (DB via Prisma)
- Pagination
- Bulk operations (update/delete)

---

## 🧩 Core Components

### 🧱 Entity: `Notification`
- Immutable domain entity with getters:
  - `id`, `title`, `text`, `read`, `createdAt`, `userId`, `isDeleted`
- Behaviors:
  - `markAsRead()`
  - `markAsDeleted()`
  - `withTitle()`, `withText()`, `setUserId()`
- Factory methods:
  - `create()` (new notification)
  - `rehydrate()` (from DB)

---

## 🔁 Mapper
### `NotificationMapper`
- Converts domain → response DTO
- Used in all read use cases
- Supports pagination via:
  - `NotificationPaginationResponse`

---

## 📡 Real-Time Notifications

### `NotificationGateway`
- WebSocket gateway (`/notification` namespace)
- Users join rooms using `userId`
- Emits events:
  - `new-message`

### `NotificationDispatcher`
- Sends real-time notifications via gateway

### `CoursePurchasedDispatcher`
- Listens to `CoursePurchasedEvent`
- Creates notification:
  - "Purchase Successful!"
- Saves to DB + sends via WebSocket

---

## 🧠 Use Cases

### 📥 Read
- `GetUserNotificationUseCase`
  - Get single notification by ID

- `GetUserNotificationsUseCase`
  - Get paginated notifications for user

### ✏️ Update
- `UpdateNotificationUseCase`
  - Marks a notification as read

- `UpdateNotificationsUseCase`
  - Marks multiple notifications as read

### 🗑️ Delete
- `DeleteNotificationUsecase`
  - Soft delete (sets `isDeleted = true`)

- `DeleteMultipleNotificationUseCase`
  - Bulk delete

---

## 🧰 Repository

### `INOTIFICATION_REPOSITORY`
Defines:
- `findAll()` (paginated)
- `findById()`
- `save()`
- `markAllAsRead()`
- `delete()` (soft delete)
- `deleteAll()` (bulk delete)

### `NotificationPrismaRepository`
- Prisma-based implementation
- Supports:
  - Pagination
  - Transactions (`TransactionContext`)
  - Filtering (`userId`, `isDeleted`)
- Uses:
  - `upsert()` for save
  - `updateManyAndReturn()` for bulk read updates

---

## 🌐 API Layer

### `NotificationController`
Secured with `VerifyJwt`

#### Endpoints:
- `GET /notifications`
  - Get user notifications (paginated)

- `GET /notifications/:id`
  - Get single notification

- `PATCH /notifications/update`
  - Mark one as read

- `PATCH /notifications/update-all`
  - Mark multiple as read

- `DELETE /notifications/delete`
  - Delete one

- `DELETE /notifications/delete-many`
  - Delete multiple

---

## 📦 DTOs
- `NotificationIdDto` → single ID
- `NotificationIdsDto` → array of IDs
- `QueryPaginationNotification` → `page`, `limit`

---

## ⚙️ Module Setup

### `NotificationModule`
- Registers:
  - Use cases
  - Facade
  - Prisma repository
- Provides:
  - `INOTIFICATION_REPOSITORY`
- Imports:
  - `JwtModule`
  - `ConfigModule`

---

## 🧠 Facade Pattern
### `NotificationFacade`
Simplifies access to:
- Get (single / list)
- Update (single / bulk)
- Delete (single / bulk)