### PR TITLE
Fix notification feature

### DIFF
--- a/src/module/notification/application/usecases/update-notifications/update-notifications.usecase.ts
+++ b/src/module/notification/application/usecases/update-notifications/update-notifications.usecase.ts
@@ -5,7 +5,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class UpdateNotificationsUseCase implements IUseCase<
-  string[],
+  string,
   Promise<Result<void>>
 > {
   constructor(
@@ -13,10 +13,21 @@ export class UpdateNotificationsUseCase implements IUseCase<
     private readonly notificationRepo: INotificationSystemRepository,
   ) {}
 
-  async execute(params: string[]): Promise<Result<void>> {
-    if (!params || !params.length)
-      return Result.fail(Errors.validation('No notification IDs provided'));
+  async execute(userId: string): Promise<Result<void>> {
+    const notificationsResult = await this.notificationRepo.findAll({ userId });
 
-    return await this.notificationRepo.markAllAsRead(params);
+    if (!notificationsResult.ok) return notificationsResult;
+
+    const unreadedMessages = notificationsResult.value.data.filter(
+      (n) => !n.getRead,
+    );
+
+    if (!unreadedMessages.length)
+      return Result.fail(Errors.notFound('All messages are readed'));
+
+    // if we reach here we need to return the ids of unreaded messages
+    const unreadedMessagesIds = unreadedMessages.map((msg) => msg.getId);
+
+    return await this.notificationRepo.markAllAsRead(unreadedMessagesIds);
   }
 }

--- a/src/module/notification/domain/repository/notification.repository.interface.ts
+++ b/src/module/notification/domain/repository/notification.repository.interface.ts
@@ -13,6 +13,8 @@ export interface INotificationSystemRepository {
   markAllAsRead: (ids: string[]) => Promise<Result<void>>;
 
   save: (notification: Notification) => Promise<Result<Notification>>;
+
+  saveMany: (notifications: Notification[]) => Promise<Result<void>>;
   // soft deletion
   delete: (id: string) => Promise<Result<void>>;
 

--- a/src/module/notification/index.ts
+++ b/src/module/notification/index.ts
@@ -1,0 +1,10 @@
+export { Notification } from './domain/entity/notification.entity';
+
+export type {
+  NotificationPaginationResult,
+  NotificationState,
+} from './domain/entity/notification.type';
+
+export { INOTIFICATION_REPOSITORY } from './domain/constant/injection.token';
+
+export { type INotificationSystemRepository } from './domain/repository/notification.repository.interface';

--- a/src/module/notification/infrastructure/notification.prisma.repository.ts
+++ b/src/module/notification/infrastructure/notification.prisma.repository.ts
@@ -89,6 +89,22 @@ export class NotificationPrismaRepository implements INotificationSystemReposito
     }
   }
 
+  async saveMany(notifications: Notification[]): Promise<Result<void>> {
+    try {
+      const manyRecord = notifications.map((n) => n.toPersistence());
+      const result = await this._db.notification.createMany({
+        data: manyRecord,
+      });
+
+      if (result.count <= 0)
+        return Result.fail(Errors.internal('Update records failed'));
+
+      return Result.ok(undefined);
+    } catch (err) {
+      return ErrorMapper.toResult(err, this._entityName);
+    }
+  }
+
   async save(notification: Notification): Promise<Result<Notification>> {
     try {
       const data: PrismaNotification = await this._db.notification.upsert({

--- a/src/module/notification/notification.module.ts
+++ b/src/module/notification/notification.module.ts
@@ -31,7 +31,7 @@ const infrastructure: Provider[] = [
 ];
 
 @Module({
-  exports: [],
+  exports: [INOTIFICATION_REPOSITORY],
   imports: [JwtModule, ConfigModule],
   controllers: [NotificationController],
   providers: [...usecases, ...infrastructure],

--- a/src/module/notification/presentation/notification.controller.ts
+++ b/src/module/notification/presentation/notification.controller.ts
@@ -45,8 +45,9 @@ export class NotificationController {
   }
 
   @Patch('update-all')
-  async updateAll(@Body() dto: NotificationIdsDto) {
-    return await this.notificationFacade.updateNotifications.execute(dto.ids);
+  async updateAll(@Req() request: Request) {
+    const { id: userId } = request['user'] as JwtPayload;
+    return await this.notificationFacade.updateNotifications.execute(userId);
   }
 
   @Delete('delete')


### PR DESCRIPTION
## Summary of Changes

### 1. UpdateNotificationsUseCase Refactor
- **Input changed**: from `string[]` (notification IDs) → `string` (userId).
- **New flow**:
  1. Fetch all notifications for the user.
  2. Filter unread notifications.
  3. If none found → return `notFound` error.
  4. Extract IDs of unread notifications.
  5. Mark those notifications as read.
- **Removed**: direct validation for empty ID array.
- **Behavior shift**: logic moved from client-driven (IDs) → server-driven (auto-detect unread).

---

### 2. Repository Interface Update
- Added new method:
  - `saveMany(notifications: Notification[]): Promise<Result<void>>`

---

### 3. Prisma Repository Enhancement
- Implemented `saveMany`:
  - Uses `createMany` for batch insert.
  - Returns failure if no records are created.
  - Includes error handling via `ErrorMapper`.

---

### 4. Module Export Change
- `INOTIFICATION_REPOSITORY` is now exported from the module.
- Enables usage in other modules (dependency injection).

---

### 5. Controller Update
- `update-all` endpoint:
  - **Before**: accepted notification IDs via request body.
  - **After**: extracts `userId` from JWT (`request.user`).
  - Calls use case with `userId` instead of IDs.
- **Impact**: endpoint is now user-based, not payload-based.

---

### 6. New Index Exports
- Centralized exports for:
  - `Notification` entity
  - Types (`NotificationPaginationResult`, `NotificationState`)
  - Repository interface
  - Injection token

---

## Overall Impact
- Shift toward **cleaner domain-driven design**:
  - Business logic centralized in use case.
  - Controller simplified.
- Improved **DX & scalability**:
  - Batch operations (`saveMany`).
  - Reusable module exports.
- More **secure & consistent API**:
  - User identity derived from JWT instead of client input.