### PR TITLE
add pagination check to unwrap response

### DIFF
--- a/src/core/common/infrastructure/nest/interceptors/result.interceptor.ts
+++ b/src/core/common/infrastructure/nest/interceptors/result.interceptor.ts
@@ -18,6 +18,11 @@ export class ResultInterceptor implements NestInterceptor {
       map((result: unknown) => {
         if (this._isResult(result)) {
           if (!result.ok) throw new DomainException(result.error);
+
+          if (this._isPagintatedStructure(result.value)) {
+            return result.value;
+          }
+
           return { data: result.value };
         }
         return result;
@@ -32,6 +37,17 @@ export class ResultInterceptor implements NestInterceptor {
       typeof obj == 'object' &&
       'ok' in obj &&
       ('value' in obj || 'error' in obj)
+    );
+  }
+
+  private _isPagintatedStructure(
+    value: unknown,
+  ): value is { data: unknown; meta: unknown } {
+    return (
+      value !== null &&
+      typeof value === 'object' &&
+      'data' in value &&
+      'meta' in value
     );
   }
 }


### PR DESCRIPTION
# PR Summary: fix/interceptor

## Overview
This PR fixes the ResultInterceptor to properly handle paginated responses without double-wrapping them in a data envelope.

## Changes

### 🔧 ResultInterceptor Enhancement

**File:** `src/core/common/infrastructure/nest/interceptors/result.interceptor.ts`

**Issue:**
Previously, all successful responses were wrapped in `{ data: result.value }`, which caused paginated responses (already structured as `{ data: [...], meta: {...} }`) to be double-wrapped.

**Solution:**
Added pagination detection logic to bypass wrapping for paginated responses.

**Before:**
```typescript
if (!result.ok) throw new DomainException(result.error);
return { data: result.value };  // Wraps everything
```

**After:**
```typescript
if (!result.ok) throw new DomainException(result.error);

if (this._isPagintatedStructure(result.value)) {
  return result.value;  // Return as-is if already paginated
}

return { data: result.value };  // Wrap only non-paginated responses
```

### 📋 New Helper Method

```typescript
private _isPagintatedStructure(
  value: unknown,
): value is { data: unknown; meta: unknown } {
  return (
    value !== null &&
    typeof value === 'object &&
    'data' in value &&
    'meta' in value
  );
}
```

**Validation:**
- Checks if value is an object (not null)
- Verifies presence of `data` property
- Verifies presence of `meta` property
- Returns `true` only for paginated structures

## Response Formats

**Non-Paginated Response (e.g., Create/Update):**
```json
{
  "data": {
    "id": "123",
    "title": "Course Title"
  }
}
```

**Paginated Response (e.g., Find Reviews):**
```json
{
  "data": [
    { "id": "1", "review": "..." },
    { "id": "2", "review": "..." }
  ],
  "meta": {
    "page": 1,
    "limit": 15,
    "total": 100,
    "pages": 7
  }
}
```

## File Statistics
- **Modified Files:** 1
- **Lines Changed:** 15 (added detection logic)
- **Impact:** Medium - Fixes response structure for paginated endpoints

## Purpose
✅ **Prevent Double-Wrapping:** Paginated responses already have proper structure  
✅ **Consistency:** Non-paginated responses still wrapped in data envelope  
✅ **Type Safety:** TypeScript guard clause for proper typing  
✅ **Backward Compatible:** Non-paginated responses maintain same format