### PR TITLE
fix global mapper in prisma

### DIFF
--- a/src/core/database/prisma-global.mapper.ts
+++ b/src/core/database/prisma-global.mapper.ts
@@ -7,7 +7,8 @@ export class ErrorMapper {
     console.error('[Prisma Error] ', err);
 
     if (err instanceof Prisma.PrismaClientKnownRequestError) {
-      switch (err.code) {
+      const code = err.code;
+      switch (code) {
         case 'P2025':
           return failure(Errors.notFound(`${entityName} not found`));
         case 'P2002':


### PR DESCRIPTION
## Changes Summary

### 📝 Commit: `fix global mapper in prisma`

**File Modified:** `src/core/database/prisma-global.mapper.ts`

#### Changes:
```diff
  export class ErrorMapper {
    console.error('[Prisma Error] ', err);
 
    if (err instanceof Prisma.PrismaClientKnownRequestError) {
-     switch (err.code) {
+     const code = err.code;
+     switch (code) {
      case 'P2025':
        return failure(Errors.notFound(`${entityName} not found`));
      case 'P2002':
```

#### What Changed:

| Aspect | Details |
|--------|---------|
| **Files Changed** | 1 file |
| **Additions** | 2 lines |
| **Deletions** | 1 line |
| **Net Change** | +2 -1 |
| **File** | `src/core/database/prisma-global.mapper.ts` |

#### Details:

The fix refactors the error handling in the Prisma global mapper by:

1. **Extracted `err.code` into a variable** - Instead of directly accessing `err.code` in the switch statement, the code now assigns it to a local `code` variable
2. **Updated switch statement** - The switch now operates on the `code` variable instead of directly on `err.code`

This is a minor refactoring that likely improves code readability and may resolve a type-checking issue or improve IDE type inference for the switch cases.

---

**Author:** Hammam Hussein  
**Date:** June 6, 2026 at 17:33 UTC