### PR TITLE
copy the runtime utils from the builder

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -39,4 +39,6 @@ COPY --from=builder /app/.npmrc ./.npmrc
 RUN pnpm install --prod --frozen-lockfile
 
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma 
+
 CMD ["node", "dist/main"]


### PR DESCRIPTION
The `fix/docker` branch contains **one commit** with Docker build fixes:

### In a Nutshell
This branch fixes a critical issue in the production Dockerfile (`Dockerfile.prod`) where Prisma runtime utilities weren't being copied from the build stage to the final runtime image. The fix ensures that all required Prisma packages (`@prisma` directory) are available at runtime.

### Changes Made

| Aspect | Details |
|--------|---------|
| **Branch** | `fix/docker` (compared to `main`) |
| **Commits** | 1 commit |
| **Files Changed** | 1 file (`Dockerfile.prod`) |
| **Lines Added/Deleted** | +2 additions, 0 deletions |
| **Author** | Hammam Hussein (@Hammamjs) |
| **Date** | 2026-06-06 |

### Specific Change

**File**: `Dockerfile.prod`

The fix adds a single line to copy the Prisma package utilities from the builder stage:

```dockerfile
COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
```

This line was added after the existing `.prisma` directory copy, ensuring that the complete Prisma runtime is available in the production image.

### Why This Matters
In multi-stage Docker builds, Prisma requires both:
- `.prisma/client` directory (already being copied)
- `@prisma` package directory (newly added)

Without this copy, the application might fail at runtime with Prisma-related errors.