### PR TITLE
move origins to env to add more flexibility

### DIFF
--- a/src/core/common/infrastructure/config/allowed-origins.ts
+++ b/src/core/common/infrastructure/config/allowed-origins.ts
@@ -1,6 +1,3 @@
 export const allowedOrigins = [
-  'http://localhost:3000',
-  'http://127.0.0.1:3000',
-  'http://localhost:3001',
-  'http://127.0.0.1:3001',
-];
+  ...(process.env.ALLOWED_URLS?.split(',') ?? []),
+].filter(Boolean);


### PR DESCRIPTION
## Changes Summary

### File Modified: `src/core/common/infrastructure/config/allowed-origins.ts`

**Before:**
```typescript
export const allowedOrigins = [
  'http://localhost:3000',
  'http://127.0.0.1:3000',
  'http://localhost:3001',
  'http://127.0.0.1:3001',
];
```

**After:**
```typescript
export const allowedOrigins = [
  ...(process.env.ALLOWED_URLS?.split(',') ?? []),
].filter(Boolean);
```

## What Was Done ✅

1. **Removed Hardcoded Origins**: Eliminated hardcoded localhost URLs (`localhost:3000`, `127.0.0.1:3000`, `localhost:3001`, `127.0.0.1:3001`)

2. **Implemented Environment-Based Configuration**: 
   - Now reads allowed origins from the `ALLOWED_URLS` environment variable
   - Uses the spread operator to expand comma-separated values into array items
   - Provides fallback to empty array if the environment variable is not set

3. **Added Filtering**:
   - Uses `.filter(Boolean)` to remove any empty strings from the resulting array

## Benefits 🎯

- **Environment-Aware**: CORS configuration is now externalized and can be set per environment (development, staging, production)
- **Security**: No hardcoded URLs exposed in the codebase
- **Flexibility**: Easy to update allowed origins without code changes
- **Scalability**: Supports multiple origins via comma-separated values in `ALLOWED_URLS` environment variable