### PR TITLE
fix: Put setDefaultResultOrder top level

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,10 +5,9 @@ import cookieParser from 'cookie-parser';
 import { ResultInterceptor, DomainExceptionFilter } from '@/core';
 import { corsOption } from './core/common/infrastructure/config/cors-option';
 import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
 
 async function bootstrap() {
-  setDefaultResultOrder('ipv4first');
-
   const app = await NestFactory.create(AppModule, { rawBody: true });
   app.use(cookieParser());
 


### PR DESCRIPTION
## Modified Files

### `src/main.ts`

**Summary:** Moved `setDefaultResultOrder('ipv4first')` call outside of the async `bootstrap()` function to module level initialization.

**Changes:**
- ❌ **Removed:** `setDefaultResultOrder('ipv4first');` call from inside the `bootstrap()` function (line 12)
- ❌ **Removed:** Empty line after the function declaration
- ✅ **Added:** `setDefaultResultOrder('ipv4first');` call at module level (line 8), right after the imports

**Why?** Setting the default DNS result order at the module level ensures it takes effect before the NestFactory creates the application, improving IPv4 priority resolution from the very start of the application lifecycle.