### PR TITLE
fix: switch from nodemailer to mailersend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "ioredis": "^5.10.1",
+<<<<<<< Updated upstream
     "nodemailer": "^8.0.10",
+=======
+    "mailersend": "^3.0.0",
+>>>>>>> Stashed changes
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,15 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.11.1
+<<<<<<< Updated upstream
       nodemailer:
         specifier: ^8.0.10
         version: 8.0.10
+=======
+      mailersend:
+        specifier: ^3.0.0
+        version: 3.0.0
+>>>>>>> Stashed changes
       pg:
         specifier: ^8.20.0
         version: 8.21.0
@@ -1652,6 +1658,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2192,6 +2202,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2565,6 +2579,9 @@ packages:
   extend-object@1.0.0:
     resolution: {integrity: sha512-0dHDIXC7y7LDmCh/lp1oYkmv73K25AMugQI07r8eFopkW6f7Ufn1q+ETMsJjnV9Am14SlElkqy3O92r6xEaxPw==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -2598,6 +2615,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2658,6 +2679,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
@@ -2687,6 +2712,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -2858,6 +2887,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3335,6 +3368,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  mailersend@3.0.0:
+    resolution: {integrity: sha512-CvP96bV4Z/4VaQmLTHDOSu2HKXjB2pwXLq76uukqdzRjoLtStCKqsHnMM/PwqEaamXHRpiHSWdNo7EdRYe00vg==}
+
   mailparser@3.9.9:
     resolution: {integrity: sha512-ulZi7h1eKm8WQmXibIgj8dmMQGDQCUS/g+XHkxxjcLDq4Dwn2ppo+0hz5Fi+ltvu4eN7mh3ykIp5RcpiWWav1w==}
 
@@ -3576,8 +3612,17 @@ packages:
     resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -4768,6 +4813,10 @@ packages:
   web-resource-inliner@8.0.0:
     resolution: {integrity: sha512-Ezr98sqXW/+OCGoUEXuOKVR+oVFlSdn1tIySEEJdiSAw4IjrW8hQkwARSSBJTSB5Us5dnytDgL0ZDliAYBhaNA==}
     engines: {node: '>=10.0.0'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -6547,6 +6596,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -7167,6 +7218,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -7565,6 +7618,8 @@ snapshots:
   extend-object@1.0.0:
     optional: true
 
+  extend@3.0.2: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -7588,6 +7643,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -7676,6 +7736,10 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -7700,6 +7764,14 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
 
   generate-function@2.3.1:
     dependencies:
@@ -7879,6 +7951,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -8548,6 +8627,13 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mailersend@3.0.0:
+    dependencies:
+      gaxios: 7.1.5
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - supports-color
+
   mailparser@3.9.9:
     dependencies:
       '@zone-eu/mailsplit': 5.4.12
@@ -9168,9 +9254,17 @@ snapshots:
 
   node-addon-api@8.8.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@1.11.0:
     dependencies:
       lodash: 4.18.1
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4: {}
 
@@ -10435,6 +10529,8 @@ snapshots:
       mime: 2.6.0
       valid-data-url: 3.0.1
     optional: true
+
+  web-streams-polyfill@3.3.3: {}
 
   webpack-node-externals@3.0.0: {}
 

--- a/src/module/auth/auth.module.ts
+++ b/src/module/auth/auth.module.ts
@@ -20,7 +20,7 @@ import {
   SignInUseCase,
 } from './index';
 import { AuthSendEmailHandler } from './application/handler/auth-email.handler';
-import { NodemailerService } from './infrastructure/security/email.service';
+import { MailersendService } from './infrastructure/security/email.service';
 import { RedisCacheRepository } from './infrastructure/repository/redis-cache.repository';
 import { CqrsModule } from '@nestjs/cqrs';
 import { GetMeUseCase } from './application/usecases/get-user/get-user.usecase';
@@ -46,7 +46,7 @@ const handlers: Provider[] = [AuthSendEmailHandler];
 const infrastructure: Provider[] = [
   BcryptService,
   TokenService,
-  NodemailerService,
+  MailersendService,
   RedisCacheRepository,
 
   {
@@ -58,7 +58,7 @@ const infrastructure: Provider[] = [
     provide: IJWTTOKEN_SERVICE,
   },
   {
-    useExisting: NodemailerService,
+    useExisting: MailersendService,
     provide: IEMAIL_SERVICE,
   },
   {

--- a/src/module/auth/infrastructure/security/email.service.ts
+++ b/src/module/auth/infrastructure/security/email.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { IEmailService } from '../../domain/service/email.service.interface';
-import * as nodemailer from 'nodemailer';
+import { EmailParams, MailerSend, Recipient, Sender } from 'mailersend';
 import { EmailServiceTemplate } from '@/module/users/application/ports/email-service';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
+<<<<<<< Updated upstream
 export class NodemailerService implements IEmailService {
   private transporter: nodemailer.Transporter;
   constructor() {
@@ -13,15 +15,40 @@ export class NodemailerService implements IEmailService {
         user: process.env.EMAIL_USER,
         pass: process.env.EMAIL_PASS,
       },
+=======
+export class MailersendService implements IEmailService {
+  private mailerSend: MailerSend;
+
+  constructor(private readonly config: ConfigService) {
+    this.mailerSend = new MailerSend({
+      apiKey: config.getOrThrow<string>('MAILER_SEND_API_KEY'),
+>>>>>>> Stashed changes
     });
   }
 
   async send(email: string, subject: string, code: string): Promise<void> {
+<<<<<<< Updated upstream
     await this.transporter.sendMail({
       from: `LMS Support <${process.env.EMAIL_USER}>`,
       to: email,
       subject,
       html: EmailServiceTemplate(subject, code),
     });
+=======
+    const sentFrom = new Sender(
+      this.config.getOrThrow<string>('MAILER_SEND_FROM'),
+      'LMS Support',
+    );
+
+    const recipients = [new Recipient(email)];
+
+    const emailParams = new EmailParams()
+      .setFrom(sentFrom)
+      .setTo(recipients)
+      .setSubject(subject)
+      .setHtml(EmailServiceTemplate(subject, code));
+
+    await this.mailerSend.email.send(emailParams);
+>>>>>>> Stashed changes
   }
 }


### PR DESCRIPTION
## 📧 Email Service Migration - MailerSend Integration

### Summary
Migrated the email service from **Nodemailer** to **MailerSend** API for improved email delivery and tracking capabilities.

---

## 📝 Changed Files

### 1. **package.json**
- **Removed**: `nodemailer` (v^8.0.10)
- **Added**: `mailersend` (v^3.0.0)

### 2. **pnpm-lock.yaml**
Updated lock file with new dependencies:
- Added `mailersend@3.0.0`
- Added transitive dependencies:
  - `agent-base@7.1.4`
  - `data-uri-to-buffer@4.0.1`
  - `extend@3.0.2`
  - `fetch-blob@3.2.0`
  - `formdata-polyfill@4.0.10`
  - `gaxios@7.1.5`
  - `https-proxy-agent@7.0.6`
  - `node-domexception@1.0.0`
  - `node-fetch@3.3.2`
  - `web-streams-polyfill@3.3.3`

### 3. **src/module/auth/auth.module.ts**
- **Line 23**: Import changed
  - From: `NodemailerService`
  - To: `MailersendService`
- **Line 49**: Provider changed
  - From: `NodemailerService`
  - To: `MailersendService`
- **Line 61**: Injection token updated
  - From: `useExisting: NodemailerService`
  - To: `useExisting: MailersendService`

### 4. **src/module/auth/infrastructure/security/email.service.ts**
**Complete service rewrite:**

#### Imports Changes
- **Removed**: `import * as nodemailer from 'nodemailer'`
- **Added**: 
  - `import { EmailParams, MailerSend, Recipient, Sender } from 'mailersend'`
  - `import { ConfigService } from '@nestjs/config'`

#### Class Changes
- **From**: `export class NodemailerService implements IEmailService`
- **To**: `export class MailersendService implements IEmailService`

#### Constructor Changes
```typescript
// Before: Nodemailer setup
private transporter: nodemailer.Transporter;
constructor() {
  this.transporter = nodemailer.createTransport({
    host: process.env.EMAIL_HOST,
    port: Number(process.env.EMAIL_PORT),
    secure: true,
    auth: {
      user: process.env.EMAIL_USER,
      pass: process.env.EMAIL_PASS,
    },
  });
}

// After: MailerSend setup
private mailerSend: MailerSend;
constructor(private readonly config: ConfigService) {
  this.mailerSend = new MailerSend({
    apiKey: config.getOrThrow<string>('MAILER_SEND_API_KEY'),
  });
}