### PR TITLE
Fix/email service

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "ioredis": "^5.10.1",
-<<<<<<< Updated upstream
-    "nodemailer": "^8.0.10",
-=======
     "mailersend": "^3.0.0",
->>>>>>> Stashed changes
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,15 +77,9 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.11.1
-<<<<<<< Updated upstream
-      nodemailer:
-        specifier: ^8.0.10
-        version: 8.0.10
-=======
       mailersend:
         specifier: ^3.0.0
         version: 3.0.0
->>>>>>> Stashed changes
       pg:
         specifier: ^8.20.0
         version: 8.21.0

--- a/src/module/auth/infrastructure/security/email.service.ts
+++ b/src/module/auth/infrastructure/security/email.service.ts
@@ -5,36 +5,16 @@ import { EmailServiceTemplate } from '@/module/users/application/ports/email-ser
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-<<<<<<< Updated upstream
-export class NodemailerService implements IEmailService {
-  private transporter: nodemailer.Transporter;
-  constructor() {
-    this.transporter = nodemailer.createTransport({
-      service: process.env.SERVICE_PROVIDER,
-      auth: {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASS,
-      },
-=======
 export class MailersendService implements IEmailService {
   private mailerSend: MailerSend;
 
   constructor(private readonly config: ConfigService) {
     this.mailerSend = new MailerSend({
       apiKey: config.getOrThrow<string>('MAILER_SEND_API_KEY'),
->>>>>>> Stashed changes
     });
   }
 
   async send(email: string, subject: string, code: string): Promise<void> {
-<<<<<<< Updated upstream
-    await this.transporter.sendMail({
-      from: `LMS Support <${process.env.EMAIL_USER}>`,
-      to: email,
-      subject,
-      html: EmailServiceTemplate(subject, code),
-    });
-=======
     const sentFrom = new Sender(
       this.config.getOrThrow<string>('MAILER_SEND_FROM'),
       'LMS Support',
@@ -49,6 +29,5 @@ export class MailersendService implements IEmailService {
       .setHtml(EmailServiceTemplate(subject, code));
 
     await this.mailerSend.email.send(emailParams);
->>>>>>> Stashed changes
   }
 }


### PR DESCRIPTION
### Overview

The `fix/email-service` branch resolves merge conflicts that arose from conflicting email service implementations between the upstream branch and stashed changes. The fix consolidates the email service to use **MailerSend** instead of Nodemailer.

---

## Changes Summary

### ✅ Issues Resolved

#### 1. **Merge Conflict in `package.json`**
   - **Problem:** Git merge conflict markers between two dependency choices
     - Upstream: `"nodemailer": "^8.0.10"`
     - Stashed: `"mailersend": "^3.0.0"`
   - **Solution:** Removed the merge conflict markers and kept only **MailerSend** dependency
   ```json
   "mailersend": "^3.0.0"
   ```

#### 2. **Merge Conflict in `pnpm-lock.yaml`**
   - **Problem:** Lock file had conflicting entries for both email service providers
   - **Solution:** Resolved to include only MailerSend entries and removed Nodemailer version references

#### 3. **Service Implementation Consolidation in `email.service.ts`**
   - **Problem:** File had merge conflict markers between two different email service implementations
     - **Upstream:** `NodemailerService` using nodemailer transporter
     - **Stashed:** `MailersendService` using MailerSend API
   
   - **Solution:** Consolidated to `MailersendService` with proper configuration:
     ```typescript
     @Injectable()
     export class MailersendService implements IEmailService {
       private mailerSend: MailerSend;
     
       constructor(private readonly config: ConfigService) {
         this.mailerSend = new MailerSend({
           apiKey: config.getOrThrow<string>('MAILER_SEND_API_KEY'),
         });
       }
     
       async send(email: string, subject: string, code: string): Promise<void> {
         const sentFrom = new Sender(
           this.config.getOrThrow<string>('MAILER_SEND_FROM'),
           'LMS Support',
         );
         const recipients = [new Recipient(email)];
         const emailParams = new EmailParams()
           .setFrom(sentFrom)
           .setTo(recipients)
           .setSubject(subject)
           .setHtml(EmailServiceTemplate(subject, code));
         
         await this.mailerSend.email.send(emailParams);
       }
     }
     ```

---

## Key Benefits

| Aspect | Details |
|--------|---------|
| **Email Provider** | Centralized on **MailerSend** API |
| **Configuration** | Uses `ConfigService` for security (environment variables for API key and sender) |
| **Clean Implementation** | Removed all Git merge conflict markers |
| **Dependency Management** | Updated `pnpm-lock.yaml` to reflect single email service dependency |
| **Type Safety** | Maintains TypeScript implementation of `IEmailService` interface |

---

## Files Modified

- ✏️ `package.json` - Consolidated dependencies
- ✏️ `pnpm-lock.yaml` - Updated lock file
- ✏️ `src/module/auth/infrastructure/security/email.service.ts` - Unified email service implementation