### PR TITLE
fix: map through user to return clear response

### DIFF
--- a/src/module/auth/application/usecases/email-verification/email-verification.response.ts
+++ b/src/module/auth/application/usecases/email-verification/email-verification.response.ts
@@ -1,8 +1,8 @@
-import { User } from '@/module/users/domain/entity/user.entity';
+import { UserResponse } from '@/module/users';
 
 export class EmailVerificationResponse {
   constructor(
-    public user: User,
+    public user: UserResponse,
     public accessToken: string,
     public refreshToken: string,
   ) {}

--- a/src/module/auth/application/usecases/email-verification/email-verification.usecase.ts
+++ b/src/module/auth/application/usecases/email-verification/email-verification.usecase.ts
@@ -14,6 +14,7 @@ import { Errors } from '@/core/common/domain/err.utils';
 import { createHash } from 'crypto';
 import { ConfigService } from '@nestjs/config';
 import type { ICacheRepository } from '@/module/auth/domain/repository/cache.repsoitory.interface';
+import { UserResponseMapper } from '@/module/users';
 
 @Injectable()
 export class EmailVerificationUseCase implements IUseCase<
@@ -83,12 +84,14 @@ export class EmailVerificationUseCase implements IUseCase<
 
     const finalUser = user.verify().updateRefreshToken(refreshToken);
 
+    const userResponse = UserResponseMapper.toResponse(finalUser);
+
     // atomic clean up and save
     await Promise.all([
       this.cacheRepo.del(`verify:${user.id}`),
       this.userRepo.save(finalUser),
     ]);
 
-    return Result.ok({ user: finalUser, accessToken, refreshToken });
+    return Result.ok({ user: userResponse, accessToken, refreshToken });
   }
 }


### PR DESCRIPTION
### Summary
Updated email verification to use `UserResponse` instead of `User` entity, implementing proper data mapping for the response.

### Files Changed: 2

#### 1. `email-verification.response.ts`
**Changes:**
- Imported `UserResponse` from `@/module/users` instead of `User` entity
- Changed the `user` property type from `User` to `UserResponse`

```diff
-import { User } from '@/module/users/domain/entity/user.entity';
+import { UserResponse } from '@/module/users';

 export class EmailVerificationResponse {
   constructor(
-    public user: User,
+    public user: UserResponse,
     public accessToken: string,
     public refreshToken: string,
   ) {}
```

#### 2. `email-verification.usecase.ts`
**Changes:**
- Added import for `UserResponseMapper` from `@/module/users`
- Mapped the final user entity to a `UserResponse` using `UserResponseMapper.toResponse(finalUser)`
- Returned the mapped user response instead of the raw entity

```diff
 import type { ICacheRepository } from '@/module/auth/domain/repository/cache.repsoitory.interface';
+import { UserResponseMapper } from '@/module/users';

 @Injectable()
 export class EmailVerificationUseCase implements IUseCase<

 const finalUser = user.verify().updateRefreshToken(refreshToken);

+const userResponse = UserResponseMapper.toResponse(finalUser);
+
 // atomic clean up and save
 await Promise.all([
   this.cacheRepo.del(`verify:${user.id}`),
   this.userRepo.save(finalUser),
 ]);

-return Result.ok({ user: finalUser, accessToken, refreshToken });
+return Result.ok({ user: userResponse, accessToken, refreshToken });
```

### Summary of Changes
**Type:** Refactor - Data Mapping  
**Purpose:** Apply proper response mapping pattern to email verification by converting the internal `User` entity to a `UserResponse` DTO before returning to the client.